### PR TITLE
feat: add qpdf engine

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -67,7 +67,7 @@ RUN \
     # Note: procps for "top" command (useful when debugging processes).
     # Note: tini is a helper for reaping zombie processes.
     apt-get update -qq &&\
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends curl gnupg procps tini python3 default-jre-headless &&\
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends curl gnupg procps tini python3 qpdf default-jre-headless &&\
     # Install fonts.
     # Credits:
     # https://github.com/arachnys/athenapdf/blob/master/cli/Dockerfile.
@@ -142,7 +142,8 @@ RUN \
     chromium --version &&\
     libreoffice --version &&\
     unoconv --version &&\
-    pdftk --version
+    pdftk --version &&\
+    qpdf --version
 
 # Copy the Gotenberg binary from the builder stage.
 COPY --from=builder /home/gotenberg /usr/bin/
@@ -152,6 +153,7 @@ ENV GC_EXCLUDE_SUBSTR "hsperfdata_root,hsperfdata_gotenberg"
 ENV CHROMIUM_BIN_PATH /usr/bin/chromium
 ENV UNOCONV_BIN_PATH /usr/bin/unoconv
 ENV PDFTK_BIN_PATH /usr/bin/pdftk
+ENV QPDF_BIN_PATH /usr/bin/qpdf
 
 USER gotenberg
 WORKDIR /home/gotenberg

--- a/pkg/modules/qpdf/doc.go
+++ b/pkg/modules/qpdf/doc.go
@@ -1,0 +1,3 @@
+// Package qpdf provides a module which abstracts the CLI tool QPDF and
+// implements the gotenberg.PDFEngine interface.
+package qpdf

--- a/pkg/modules/qpdf/qpdf.go
+++ b/pkg/modules/qpdf/qpdf.go
@@ -1,0 +1,111 @@
+package qpdf
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/gotenberg/gotenberg/v7/pkg/gotenberg"
+	"go.uber.org/zap"
+)
+
+func init() {
+	gotenberg.MustRegisterModule(QPDF{})
+}
+
+// QPDF abstracts the CLI tool QPDF and implements the gotenberg.QPDF
+// interface.
+type QPDF struct {
+	binPath string
+}
+
+// Descriptor returns a QPDF's module descriptor.
+func (QPDF) Descriptor() gotenberg.ModuleDescriptor {
+	return gotenberg.ModuleDescriptor{
+		ID:  "qpdf",
+		New: func() gotenberg.Module { return new(QPDF) },
+	}
+}
+
+// Provision sets the modules properties. It returns an error if the
+// environment variable QPDF_BIN_PATH is not set.
+func (engine *QPDF) Provision(_ *gotenberg.Context) error {
+	binPath, ok := os.LookupEnv("QPDF_BIN_PATH")
+	if !ok {
+		return errors.New("QPDF_BIN_PATH environment variable is not set")
+	}
+
+	engine.binPath = binPath
+
+	return nil
+}
+
+// Validate validates the module properties.
+func (engine QPDF) Validate() error {
+	_, err := os.Stat(engine.binPath)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("QPDF binary path does not exist: %w", err)
+	}
+
+	return nil
+}
+
+// Metrics returns the metrics.
+func (engine QPDF) Metrics() ([]gotenberg.Metric, error) {
+	return []gotenberg.Metric{
+		{
+			Name:        "qpdf_active_instances_count",
+			Description: "Current number of active QPDF instances.",
+			Read: func() float64 {
+				activeInstancesCountMu.RLock()
+				defer activeInstancesCountMu.RUnlock()
+
+				return activeInstancesCount
+			},
+		},
+	}, nil
+}
+
+// Merge merges the given PDFs into a unique PDF.
+func (engine QPDF) Merge(ctx context.Context, logger *zap.Logger, inputPaths []string, outputPath string) error {
+	var args []string
+	args = append(args, "--empty")
+	args = append(args, "--pages", inputPaths...)
+	args = append(args, "--", outputPath)
+
+	cmd, err := gotenberg.CommandContext(ctx, logger, engine.binPath, args...)
+	if err != nil {
+		return fmt.Errorf("create command: %w", err)
+	}
+
+	activeInstancesCountMu.Lock()
+	activeInstancesCount += 1
+	activeInstancesCountMu.Unlock()
+
+	err = cmd.Exec()
+
+	activeInstancesCountMu.Lock()
+	activeInstancesCount -= 1
+	activeInstancesCountMu.Unlock()
+
+	if err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("merge PDFs with QPDF: %w", err)
+}
+
+var (
+	activeInstancesCount   float64
+	activeInstancesCountMu sync.RWMutex
+)
+
+var (
+	_ gotenberg.Module          = (*QPDF)(nil)
+	_ gotenberg.Provisioner     = (*QPDF)(nil)
+	_ gotenberg.Validator       = (*QPDF)(nil)
+	_ gotenberg.MetricsProvider = (*QPDF)(nil)
+	_ gotenberg.PDFEngine       = (*QPDF)(nil)
+)

--- a/pkg/modules/qpdf/qpdf_test.go
+++ b/pkg/modules/qpdf/qpdf_test.go
@@ -1,0 +1,144 @@
+package qpdf
+
+import (
+	"context"
+	"errors"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/gotenberg/gotenberg/v7/pkg/gotenberg"
+	"go.uber.org/zap"
+)
+
+func TestQPDF_Descriptor(t *testing.T) {
+	descriptor := QPDF{}.Descriptor()
+
+	actual := reflect.TypeOf(descriptor.New())
+	expect := reflect.TypeOf(new(QPDF))
+
+	if actual != expect {
+		t.Errorf("expected '%s' but got '%s'", expect, actual)
+	}
+}
+
+func TestQPDF_Provision(t *testing.T) {
+	mod := new(QPDF)
+	ctx := gotenberg.NewContext(gotenberg.ParsedFlags{}, nil)
+
+	err := mod.Provision(ctx)
+	if err != nil {
+		t.Errorf("expected no error but got: %v", err)
+	}
+}
+
+
+func TestQPDF_Validate(t *testing.T) {
+	for i, tc := range []struct {
+		binPath   string
+		expectErr bool
+	}{
+		{
+			expectErr: true,
+		},
+		{
+			binPath:   "/foo",
+			expectErr: true,
+		},
+		{
+			binPath: os.Getenv("QPDF_BIN_PATH"),
+		},
+	} {
+		mod := new(QPDF)
+		mod.binPath = tc.binPath
+		err := mod.Validate()
+
+		if tc.expectErr && err == nil {
+			t.Errorf("test %d: expected error but got: %v", i, err)
+		}
+
+		if !tc.expectErr && err != nil {
+			t.Errorf("test %d: expected no error but got: %v", i, err)
+		}
+	}
+}
+
+func TestQPDF_Metrics(t *testing.T) {
+	metrics, err := new(QPDF).Metrics()
+	if err != nil {
+		t.Errorf("expected no error but got: %v", err)
+	}
+
+	if len(metrics) != 1 {
+		t.Errorf("expected %d metrics, but got %d", 1, len(metrics))
+	}
+
+	actual := metrics[0].Read()
+	if actual != 0 {
+		t.Errorf("expected %d QPDF instances, but got %f", 0, actual)
+	}
+}
+
+func TestQPDF_Merge(t *testing.T) {
+	for i, tc := range []struct {
+		ctx        context.Context
+		inputPaths []string
+		expectErr  bool
+	}{
+		{
+			ctx: context.TODO(),
+			inputPaths: []string{
+				"/tests/test/testdata/pdfengines/sample1.pdf",
+			},
+		},
+		{
+			ctx: context.TODO(),
+			inputPaths: []string{
+				"/tests/test/testdata/pdfengines/sample1.pdf",
+				"/tests/test/testdata/pdfengines/sample2.pdf",
+			},
+		},
+		{
+			ctx:       nil,
+			expectErr: true,
+		},
+		{
+			ctx: context.TODO(),
+			inputPaths: []string{
+				"foo",
+			},
+			expectErr: true,
+		},
+	} {
+		func() {
+			mod := new(QPDF)
+
+			err := mod.Provision(nil)
+			if err != nil {
+				t.Fatalf("test %d: expected error but got: %v", i, err)
+			}
+
+			outputDir, err := gotenberg.MkdirAll()
+			if err != nil {
+				t.Fatalf("test %d: expected error but got: %v", i, err)
+			}
+
+			defer func() {
+				err := os.RemoveAll(outputDir)
+				if err != nil {
+					t.Fatalf("test %d: expected no error but got: %v", i, err)
+				}
+			}()
+
+			err = mod.Merge(tc.ctx, zap.NewNop(), tc.inputPaths, outputDir+"/foo.pdf")
+
+			if tc.expectErr && err == nil {
+				t.Errorf("test %d: expected error but got: %v", i, err)
+			}
+
+			if !tc.expectErr && err != nil {
+				t.Errorf("test %d: expected no error but got: %v", i, err)
+			}
+		}()
+	}
+}

--- a/pkg/standard/imports.go
+++ b/pkg/standard/imports.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/pdfcpu"
 	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/pdfengines"
 	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/pdftk"
+	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/qpdf"
 	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/prometheus"
 	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/webhook"
 )


### PR DESCRIPTION
I never programmed in Go before, so I don't clearly understand what I am doing.

This PR aims to add QPDF as a tool to merge PDFs, because it can deal with invalid PDFs files, which PDFtk can not do.

Also, I think that would be cool if Gotenberg have another tool on it.