### PR TITLE
feat: add --chromium-proxy-server property for the Chromium module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ CHROMIUM_USER_AGENT=
 CHROMIUM_INCOGNITO=false
 CHROMIUM_IGNORE_CERTIFICATE_ERRORS=false
 CHROMIUM_ALLOW_FILE_ACCESS_FROM_FILES=false
+CHROMIUM_PROXY_SERVER=
 CHROMIUM_ALLOW_LIST=
 CHROMIUM_DENY_LIST="^file:///[^tmp].*"
 CHROMIUM_DISABLE_ROUTES=false
@@ -79,6 +80,7 @@ run: ## Start a Gotenberg container
 	--chromium-incognito=$(CHROMIUM_INCOGNITO) \
 	--chromium-ignore-certificate-errors=$(CHROMIUM_IGNORE_CERTIFICATE_ERRORS) \
 	--chromium-allow-file-access-from-files=$(CHROMIUM_ALLOW_FILE_ACCESS_FROM_FILES) \
+	--chromium-proxy-server=$(CHROMIUM_PROXY_SERVER) \
 	--chromium-allow-list=$(CHROMIUM_ALLOW_LIST) \
 	--chromium-deny-list=$(CHROMIUM_DENY_LIST) \
 	--chromium-disable-routes=$(CHROMIUM_DISABLE_ROUTES) \

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.16
 	github.com/nwaples/rardecode v1.1.2 // indirect
 	github.com/pdfcpu/pdfcpu v0.3.12
-	github.com/pierrec/lz4/v4 v4.1.9 // indirect
+	github.com/pierrec/lz4/v4 v4.1.10 // indirect
 	github.com/prometheus/client_golang v1.11.0
 	github.com/russross/blackfriday/v2 v2.1.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5/go.mod h1:nZgzb
 github.com/pdfcpu/pdfcpu v0.3.12 h1:B+MdKisilWNSk5OCO58Z9U6H93usH73xqk6hMOaZCls=
 github.com/pdfcpu/pdfcpu v0.3.12/go.mod h1:8XVBtVxuuIuSZL4Ez15Q4QoC+H8zeAaGnuiOEwAk8jA=
 github.com/pierrec/lz4/v4 v4.1.2/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/pierrec/lz4/v4 v4.1.9 h1:xkrjwpOP5xg1k4Nn4GX4a4YFGhscyQL/3EddJ1Xxqm8=
-github.com/pierrec/lz4/v4 v4.1.9/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pierrec/lz4/v4 v4.1.10 h1:H0LgOg/8kTVhiN8ESXFa+gvt9udNp1hQ+mYNDdcMPTM=
+github.com/pierrec/lz4/v4 v4.1.10/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/modules/chromium/chromium_test.go
+++ b/pkg/modules/chromium/chromium_test.go
@@ -234,6 +234,7 @@ func TestChromium_PDF(t *testing.T) {
 		incognito                bool
 		ignoreCertificateErrors  bool
 		allowFileAccessFromFiles bool
+		proxyServer              string
 		allowList                *regexp.Regexp
 		denyList                 *regexp.Regexp
 		expectErr                bool
@@ -297,6 +298,7 @@ func TestChromium_PDF(t *testing.T) {
 			incognito:                true,
 			ignoreCertificateErrors:  true,
 			allowFileAccessFromFiles: true,
+			proxyServer:              "foo",
 		},
 		{
 			URL: "file:///tests/test/testdata/chromium/html/sample1/index.html",
@@ -348,6 +350,7 @@ func TestChromium_PDF(t *testing.T) {
 			mod.incognito = tc.incognito
 			mod.ignoreCertificateErrors = tc.ignoreCertificateErrors
 			mod.allowFileAccessFromFiles = tc.allowFileAccessFromFiles
+			mod.proxyServer = tc.proxyServer
 
 			if tc.allowList == nil {
 				tc.allowList = regexp.MustCompile("")


### PR DESCRIPTION
Closes #376.

Also:

* Fixe an issue with the `--chromium-user-agent` property; it was not correctly bound internally (sigh).
* Chore: update Go dependencies.