### PR TITLE
feat: add ghostcript module for conversion to PDF/A and merging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /coverage.html
 /coverage.txt
+
+#Intellij IDEA project files
+.idea

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ GOTENBERG_USER_GID=1001
 GOTENBERG_USER_UID=1001
 NOTO_COLOR_EMOJI_VERSION=v2.028 # See https://github.com/googlefonts/noto-emoji/releases.
 PDFTK_VERSION=1527259628 # See https://gitlab.com/pdftk-java/pdftk/-/releases - Binary package.
+GHOSTSCRIPT_VERSION=9.55.0-linux-x86_64 # See https://github.com/ArtifexSoftware/ghostpdl-downloads/releases
 GOLANGCI_LINT_VERSION=v1.43.0 # See https://github.com/golangci/golangci-lint/releases.
 
 .PHONY: build
@@ -23,6 +24,7 @@ build: ## Build the Gotenberg's Docker image
 	--build-arg GOTENBERG_USER_UID=$(GOTENBERG_USER_UID) \
 	--build-arg NOTO_COLOR_EMOJI_VERSION=$(NOTO_COLOR_EMOJI_VERSION) \
 	--build-arg PDFTK_VERSION=$(PDFTK_VERSION) \
+	--build-arg GHOSTSCRIPT_VERSION=$(GHOSTSCRIPT_VERSION) \
 	-t $(DOCKER_REPOSITORY)/gotenberg:$(GOTENBERG_VERSION) \
 	-f build/Dockerfile .
 
@@ -148,4 +150,5 @@ release: ## Build the Gotenberg's Docker image for many platforms, then push it 
 	$(GOTENBERG_USER_GID) \
 	$(GOTENBERG_USER_UID) \
 	$(PDFTK_VERSION) \
+	$(GHOSTSCRIPT_VERSION) \
 	$(DOCKER_REPOSITORY)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -50,6 +50,7 @@ ARG GOTENBERG_USER_GID
 ARG GOTENBERG_USER_UID
 ARG NOTO_COLOR_EMOJI_VERSION
 ARG PDFTK_VERSION
+ARG GHOSTSCRIPT_VERSION
 
 # Script for installing either Google Chrome stable on amd64 architecture or
 # Chromium on other architectures.
@@ -121,7 +122,7 @@ RUN \
     # See https://github.com/gotenberg/gotenberg/pull/322.
     echo "deb https://httpredir.debian.org/debian/ sid main contrib non-free" >> /etc/apt/sources.list &&\
     apt-get update -qq &&\
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -t sid libreoffice &&\
+#    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -t sid libreoffice &&\
     # Download unoconv (Python script).
     curl -Ls https://raw.githubusercontent.com/dagwieers/unoconv/master/unoconv -o /usr/bin/unoconv &&\
     chmod +x /usr/bin/unoconv &&\
@@ -133,6 +134,11 @@ RUN \
     chmod a+x /usr/bin/pdftk-all.jar &&\
     # Download QPDF.
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends qpdf &&\
+    # Download Ghostscript
+    wget "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9550/ghostscript-$GHOSTSCRIPT_VERSION.tgz"  &&\
+    tar -zxvf ghostscript-$GHOSTSCRIPT_VERSION.tgz &&\
+    cp ghostscript-$GHOSTSCRIPT_VERSION/gs* /usr/bin/ghostscript &&\
+    chmod a+x /usr/bin/ghostscript &&\
     # See https://github.com/nextcloud/docker/issues/380.
     mkdir -p /usr/share/man/man1mkdir -p /usr/share/man/man1 &&\
     # Cleanup.
@@ -142,10 +148,11 @@ RUN \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&\
     # Print versions of main dependencies.
     chromium --version &&\
-    libreoffice --version &&\
-    unoconv --version &&\
+#    libreoffice --version &&\
+#    unoconv --version &&\
     pdftk --version &&\
-    qpdf --version
+    qpdf --version &&\
+    ghostscript --version
 
 # Copy the Gotenberg binary from the builder stage.
 COPY --from=builder /home/gotenberg /usr/bin/
@@ -156,6 +163,7 @@ ENV CHROMIUM_BIN_PATH /usr/bin/chromium
 ENV UNOCONV_BIN_PATH /usr/bin/unoconv
 ENV PDFTK_BIN_PATH /usr/bin/pdftk
 ENV QPDF_BIN_PATH /usr/bin/qpdf
+ENV GHOSTSCRIPT_BIN_PATH /usr/bin/ghostscript
 
 USER gotenberg
 WORKDIR /home/gotenberg

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,8 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/klauspost/compress v1.13.6 // indirect
-	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/labstack/echo/v4 v4.6.1
 	github.com/labstack/gommon v0.3.1
-	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/microcosm-cc/bluemonday v1.0.16
 	github.com/nwaples/rardecode v1.1.2 // indirect
@@ -28,11 +26,9 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0
 	go.uber.org/zap v1.19.1
-	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // indirect
 	golang.org/x/net v0.0.0-20210913180222-943fd674d43e
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 	golang.org/x/text v0.3.7
 )
@@ -51,8 +47,10 @@ require (
 	github.com/hhrutter/lzw v0.0.0-20190829144645-6f07a24e8650 // indirect
 	github.com/hhrutter/tiff v0.0.0-20190829141212-736cae8d0bc7 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
@@ -61,6 +59,8 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.1 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
+	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/pkg/modules/ghostscript/doc.go
+++ b/pkg/modules/ghostscript/doc.go
@@ -1,0 +1,3 @@
+// Package ghostscript provides a module which abstracts the CLI tool ghostscript and
+// implements the gotenberg.PDFEngine interface.
+package ghostscript

--- a/pkg/modules/ghostscript/ghostscript.go
+++ b/pkg/modules/ghostscript/ghostscript.go
@@ -67,7 +67,7 @@ func (engine Ghostscript) Metrics() ([]gotenberg.Metric, error) {
 	}, nil
 }
 
-// Merge is not available for this PDF engine.
+// Merge merges PDFs with Ghostscript.
 func (engine Ghostscript) Merge(ctx context.Context, logger *zap.Logger, inputPaths []string, outputPath string) error {
 	var args []string
 	args = append(args, "-dBATCH")

--- a/pkg/modules/ghostscript/ghostscript.go
+++ b/pkg/modules/ghostscript/ghostscript.go
@@ -1,0 +1,132 @@
+package ghostscript
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/gotenberg/gotenberg/v7/pkg/gotenberg"
+	"go.uber.org/zap"
+	"os"
+	"sync"
+)
+
+func init() {
+	gotenberg.MustRegisterModule(Ghostscript{})
+}
+
+// Ghostscript abstracts the CLI tool Ghostscript and implements the gotenberg.PDFEngine
+// interface.
+type Ghostscript struct {
+	binPath string
+}
+
+// Descriptor returns a QPDF's module descriptor.
+func (Ghostscript) Descriptor() gotenberg.ModuleDescriptor {
+	return gotenberg.ModuleDescriptor{
+		ID:  "ghostscript",
+		New: func() gotenberg.Module { return new(Ghostscript) },
+	}
+}
+
+// Provision sets the modules properties. It returns an error if the
+// environment variable QPDF_BIN_PATH is not set.
+func (engine *Ghostscript) Provision(_ *gotenberg.Context) error {
+	binPath, ok := os.LookupEnv("GHOSTSCRIPT_BIN_PATH")
+	if !ok {
+		return errors.New("GHOSTSCRIPT_BIN_PATH environment variable is not set")
+	}
+
+	engine.binPath = binPath
+
+	return nil
+}
+
+// Validate validates the module properties.
+func (engine Ghostscript) Validate() error {
+	_, err := os.Stat(engine.binPath)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("ghostscript binary path does not exist: %w", err)
+	}
+
+	return nil
+}
+
+// Metrics returns the metrics.
+func (engine Ghostscript) Metrics() ([]gotenberg.Metric, error) {
+	return []gotenberg.Metric{
+		{
+			Name:        "ghostscript_active_instances_count",
+			Description: "Current number of active Ghostscript instances.",
+			Read: func() float64 {
+				activeInstancesCountMu.RLock()
+				defer activeInstancesCountMu.RUnlock()
+
+				return activeInstancesCount
+			},
+		},
+	}, nil
+}
+
+// Merge is not available for this PDF engine.
+func (engine Ghostscript) Merge(ctx context.Context, logger *zap.Logger, inputPaths []string, outputPath string) error {
+	return fmt.Errorf("merge PDF with Ghostscript: %w", gotenberg.ErrPDFEngineMethodNotAvailable)
+}
+
+// Convert converts PDF with this engine
+func (engine Ghostscript) Convert(ctx context.Context, logger *zap.Logger, format, inputPath, outputPath string) error {
+	var pdfALevel string
+
+	switch format {
+	case gotenberg.FormatPDFA1b:
+		pdfALevel = "1"
+	case gotenberg.FormatPDFA2b:
+		pdfALevel = "2"
+	case gotenberg.FormatPDFA3b:
+		pdfALevel = "3"
+	default:
+		return fmt.Errorf("convert PDF to '%s' with ghostsript: %w", format, gotenberg.ErrPDFFormatNotAvailable)
+	}
+
+	var args []string
+	args = append(args, fmt.Sprintf("-dPDFA=%s", pdfALevel))
+	args = append(args, "-dBATCH")
+	args = append(args, "-dNOPAUSE")
+	args = append(args, "-sColorConversionStrategy=UseDeviceIndependentColor")
+	args = append(args, "-sDEVICE=pdfwrite")
+	args = append(args, "-dPDFACompatibilityPolicy=1")
+	args = append(args, fmt.Sprintf("-sOutputFile=%s", outputPath))
+	args = append(args, inputPath)
+
+	cmd, err := gotenberg.CommandContext(ctx, logger, engine.binPath, args...)
+	if err != nil {
+		return fmt.Errorf("create command: %w", err)
+	}
+
+	activeInstancesCountMu.Lock()
+	activeInstancesCount += 1
+	activeInstancesCountMu.Unlock()
+
+	err = cmd.Exec()
+
+	activeInstancesCountMu.Lock()
+	activeInstancesCount -= 1
+	activeInstancesCountMu.Unlock()
+
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("convert PDF to '%s' with Ghostscript: %w", format, err)
+}
+
+var (
+	activeInstancesCount   float64
+	activeInstancesCountMu sync.RWMutex
+)
+
+var (
+	_ gotenberg.Module          = (*Ghostscript)(nil)
+	_ gotenberg.Provisioner     = (*Ghostscript)(nil)
+	_ gotenberg.Validator       = (*Ghostscript)(nil)
+	_ gotenberg.MetricsProvider = (*Ghostscript)(nil)
+	_ gotenberg.PDFEngine       = (*Ghostscript)(nil)
+)

--- a/pkg/modules/ghostscript/ghostscript_test.go
+++ b/pkg/modules/ghostscript/ghostscript_test.go
@@ -1,0 +1,228 @@
+package ghostscript
+
+import (
+	"context"
+	"errors"
+	"github.com/gotenberg/gotenberg/v7/pkg/gotenberg"
+	"go.uber.org/zap"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestGhostscript_Descriptor(t *testing.T) {
+	descriptor := Ghostscript{}.Descriptor()
+
+	actual := reflect.TypeOf(descriptor.New())
+	expect := reflect.TypeOf(new(Ghostscript))
+
+	if actual != expect {
+		t.Errorf("expected '%s' but got '%s'", expect, actual)
+	}
+}
+
+func TestGhostscript_Provision(t *testing.T) {
+	mod := new(Ghostscript)
+	ctx := gotenberg.NewContext(gotenberg.ParsedFlags{}, nil)
+
+	err := mod.Provision(ctx)
+	if err != nil {
+		t.Errorf("expected no error but got: %v", err)
+	}
+}
+
+func TestGhostscript_Validate(t *testing.T) {
+	for i, tc := range []struct {
+		binPath   string
+		expectErr bool
+	}{
+		{
+			expectErr: true,
+		},
+		{
+			binPath:   "/foo",
+			expectErr: true,
+		},
+		{
+			binPath: os.Getenv("GHOSTSCRIPT_BIN_PATH"),
+		},
+	} {
+		mod := new(Ghostscript)
+		mod.binPath = tc.binPath
+		err := mod.Validate()
+
+		if tc.expectErr && err == nil {
+			t.Errorf("test %d: expected error but got: %v", i, err)
+		}
+
+		if !tc.expectErr && err != nil {
+			t.Errorf("test %d: expected no error but got: %v", i, err)
+		}
+	}
+}
+
+func TestGhostscript_Metrics(t *testing.T) {
+	metrics, err := new(Ghostscript).Metrics()
+	if err != nil {
+		t.Errorf("expected no error but got: %v", err)
+	}
+
+	if len(metrics) != 1 {
+		t.Errorf("expected %d metrics, but got %d", 1, len(metrics))
+	}
+
+	actual := metrics[0].Read()
+	if actual != 0 {
+		t.Errorf("expected %d Ghostscript instances, but got %f", 0, actual)
+	}
+}
+
+func TestGhostscript_Merge(t *testing.T) {
+	mod := new(Ghostscript)
+	err := mod.Merge(context.TODO(), zap.NewNop(), []string{}, "")
+
+	if !errors.Is(err, gotenberg.ErrPDFEngineMethodNotAvailable) {
+		t.Errorf("expected error %v, but got: %v", gotenberg.ErrPDFEngineMethodNotAvailable, err)
+	}
+}
+
+func TestGhostscript_Convert(t *testing.T) {
+	for i, tc := range []struct {
+		ctx        context.Context
+		inputPath  string
+		expectErr  bool
+		format string
+	}{
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA1b,
+			inputPath: "/tests/test/testdata/pdfengines/sample1.pdf",
+		},
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA1a,
+			inputPath: "/tests/test/testdata/pdfengines/sample1.pdf",
+			expectErr: true,
+		},
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA2b,
+			inputPath: "/tests/test/testdata/pdfengines/sample1.pdf",
+		},
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA2a,
+			inputPath: "/tests/test/testdata/pdfengines/sample1.pdf",
+			expectErr: true,
+		},
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA2u,
+			inputPath: "/tests/test/testdata/pdfengines/sample1.pdf",
+			expectErr: true,
+		},
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA3b,
+			inputPath: "/tests/test/testdata/pdfengines/sample1.pdf",
+		},
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA3a,
+			inputPath: "/tests/test/testdata/pdfengines/sample1.pdf",
+			expectErr: true,
+		},
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA3u,
+			inputPath: "/tests/test/testdata/pdfengines/sample1.pdf",
+			expectErr: true,
+		},
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA1b,
+			inputPath: "/tests/test/testdata/pdfengines/sample2.pdf",
+		},
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA1a,
+			inputPath: "/tests/test/testdata/pdfengines/sample2.pdf",
+			expectErr: true,
+		},
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA2b,
+			inputPath: "/tests/test/testdata/pdfengines/sample2.pdf",
+		},
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA2a,
+			inputPath: "/tests/test/testdata/pdfengines/sample2.pdf",
+			expectErr: true,
+		},
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA2u,
+			inputPath: "/tests/test/testdata/pdfengines/sample2.pdf",
+			expectErr: true,
+		},
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA3b,
+			inputPath: "/tests/test/testdata/pdfengines/sample2.pdf",
+		},
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA3a,
+			inputPath: "/tests/test/testdata/pdfengines/sample2.pdf",
+			expectErr: true,
+		},
+		{
+			ctx: context.TODO(),
+			format: gotenberg.FormatPDFA3u,
+			inputPath: "/tests/test/testdata/pdfengines/sample2.pdf",
+			expectErr: true,
+		},
+		{
+			ctx:       nil,
+			expectErr: true,
+		},
+		{
+			ctx: context.TODO(),
+			inputPath: "foo",
+			expectErr: true,
+		},
+	} {
+		func() {
+			mod := new(Ghostscript)
+
+			err := mod.Provision(nil)
+			if err != nil {
+				t.Fatalf("test %d: expected error but got: %v", i, err)
+			}
+
+			outputDir, err := gotenberg.MkdirAll()
+			if err != nil {
+				t.Fatalf("test %d: expected error but got: %v", i, err)
+			}
+
+			defer func() {
+				err := os.RemoveAll(outputDir)
+				if err != nil {
+					t.Fatalf("test %d: expected no error but got: %v", i, err)
+				}
+			}()
+
+			err = mod.Convert(tc.ctx, zap.NewNop(), tc.format, tc.inputPath, outputDir+"/foo.pdf")
+
+			if tc.expectErr && err == nil {
+				t.Errorf("test %d: expected error but got: %v", i, err)
+			}
+
+			if !tc.expectErr && err != nil {
+				t.Errorf("test %d: expected no error but got: %v", i, err)
+			}
+		}()
+	}
+
+}

--- a/pkg/standard/imports.go
+++ b/pkg/standard/imports.go
@@ -5,6 +5,7 @@ import (
 	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/api"
 	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/chromium"
 	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/gc"
+	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/ghostscript"
 	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/libreoffice"
 	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/libreoffice/pdfengine"
 	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/libreoffice/unoconv"


### PR DESCRIPTION
Creates a [Ghostscript](https://ghostscript.com/) module for conversion to PDF/A-1b, PDF/A-2b, PDF/A-3b

Unoconv keeps messing fonts in my PDFs when converting HTML to PDF/A-1a, so I found Ghostscript, which doesn't have these problems.

Debian repositories should have older version of ghostscript, but I keep getting dpkg errors, when trying to install ghostscript from repository, so I had to download it from their's github.

It will be great to have some feedback :)

UPD: added support for merging PDF
