### PR TITLE
feat: add Noto CJK fonts

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -103,6 +103,7 @@ RUN \
     fonts-liberation \
     fonts-liberation2 \
     fonts-linuxlibertine \
+    fonts-noto-cjk \
     fonts-noto-core \
     fonts-noto-mono \
     fonts-noto-ui-core \


### PR DESCRIPTION
`ttf-wqy-zenhei` is a community-maintained font that only includes a subset of CJK characters, and was last updated 10 years ago.

Noto Sans CJK and Noto Serif CJK (https://github.com/googlefonts/noto-cjk) by Google and Apple are the go-to fonts for compatibility now.