### PR TITLE
add basic windows support

### DIFF
--- a/pkg/gotenberg/cmd_darwin.go
+++ b/pkg/gotenberg/cmd_darwin.go
@@ -1,0 +1,20 @@
+package gotenberg
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func terminateProcess(pid int) error {
+	// Signal the process group (-pid), not just the process, so that the process
+	// and all its children are signaled. Else, child procs can keep running and
+	// keep the stdout/stderr fd open and cause cmd.Wait to hang.
+	return syscall.Kill(-pid, syscall.SIGTERM)
+}
+
+func setProcessGroupID(cmd *exec.Cmd) {
+	// Set process group ID so the cmd and all its children become a new
+	// process group. This allows Stop to SIGTERM the cmd's process group
+	// without killing this process (i.e. this code here).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}

--- a/pkg/gotenberg/cmd_linux.go
+++ b/pkg/gotenberg/cmd_linux.go
@@ -1,0 +1,20 @@
+package gotenberg
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func terminateProcess(pid int) error {
+	// Signal the process group (-pid), not just the process, so that the process
+	// and all its children are signaled. Else, child procs can keep running and
+	// keep the stdout/stderr fd open and cause cmd.Wait to hang.
+	return syscall.Kill(-pid, syscall.SIGTERM)
+}
+
+func setProcessGroupID(cmd *exec.Cmd) {
+	// Set process group ID so the cmd and all its children become a new
+	// process group. This allows Stop to SIGTERM the cmd's process group
+	// without killing this process (i.e. this code here).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}

--- a/pkg/gotenberg/cmd_windows.go
+++ b/pkg/gotenberg/cmd_windows.go
@@ -1,0 +1,20 @@
+package gotenberg
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+// Stop stops the command by sending its process group a SIGTERM signal.
+// Stop is idempotent. An error should only be returned in the rare case that
+// Stop is called immediately after the command ends but before Start can
+// update its internal state.
+func terminateProcess(pid int) error {
+	kill := exec.Command("TASKKILL", "/T", "/F", "/PID", fmt.Sprintf("%d", pid))
+	return kill.Run()
+}
+
+func setProcessGroupID(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+}


### PR DESCRIPTION
I wanted to run gotenberg in my local windows server, but it is currently only support linux so i add basic support for windows and it worked,

i know supporting windows in not in your focus but consider accepting this pr for other people like me

the changes are minimal and easy to review 