### PR TITLE
New `forms/pdfengines/compress` endpoint

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -138,6 +138,8 @@ RUN \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends qpdf &&\
     # See https://github.com/nextcloud/docker/issues/380.
     mkdir -p /usr/share/man/man1mkdir -p /usr/share/man/man1 &&\
+    # Download ghostscript
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends ghostscript &&\
     # Cleanup.
     # Note: the Debian image does automatically a clean after each install thanks to a hook.
     # Therefore, there is no need for apt-get clean.
@@ -160,6 +162,7 @@ ENV UNOCONV_BIN_PATH /usr/bin/unoconv
 ENV LIBREOFFICE_BIN_PATH /usr/lib/libreoffice/program/soffice.bin
 ENV PDFTK_BIN_PATH /usr/bin/pdftk
 ENV QPDF_BIN_PATH /usr/bin/qpdf
+ENV GHOSTSCRIPT_BIN_PATH /usr/bin/gs
 
 USER gotenberg
 WORKDIR /home/gotenberg

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -356,6 +356,56 @@ paths:
           description: >-
             Bad Request, e.g. Invalid form data: no form file found for extensions: [.pdf]; form value 'pdfFormat' is required
 
+  /forms/pdfengines/compress:
+    post:
+      tags:
+        - pdfengines
+      summary: Compress a PDF
+      externalDocs:
+        url: https://gotenberg.dev/docs/modules/pdf-engines
+      description: >-
+        This route accepts a PDF file for compressing.
+      parameters:
+        - in: header
+          name: Gotenberg-Output-Filename
+          description: >-
+            By default, the API generates a UUID filename.
+            However, you may also specify the filename per request,
+            thanks to the Gotenberg-Output-Filename header.
+            Caution! The API adds the file extension automatically; you don't have to set it.
+          schema:
+            type: string
+          required: false
+        - in: header
+          name: Gotenberg-Trace
+          description: >-
+            The trace, or request ID, identifies a request in the logs.
+
+            By default, the API generates a UUID trace for each request.
+            However, you may also specify the trace per request, thanks to the Gotenberg-Trace header.
+          schema:
+            type: string
+          required: false
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+              required:
+                - files
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessfulPDF'
+        '400':
+          description: >-
+            Bad Request, e.g. Invalid form data: no form file found for extensions: [.pdf];
+
 components:
   schemas:
     HTMLConvertRequestBody:

--- a/pkg/gotenberg/mocks.go
+++ b/pkg/gotenberg/mocks.go
@@ -28,6 +28,7 @@ func (mod ValidatorMock) Validate() error {
 type PDFEngineMock struct {
 	MergeMock   func(ctx context.Context, logger *zap.Logger, inputPaths []string, outputPath string) error
 	ConvertMock func(ctx context.Context, logger *zap.Logger, format, inputPath, outputPath string) error
+	CompressMock func(ctx context.Context, logger *zap.Logger, inputPath string, outputPath string) error
 }
 
 func (engine PDFEngineMock) Merge(ctx context.Context, logger *zap.Logger, inputPaths []string, outputPath string) error {
@@ -36,6 +37,10 @@ func (engine PDFEngineMock) Merge(ctx context.Context, logger *zap.Logger, input
 
 func (engine PDFEngineMock) Convert(ctx context.Context, logger *zap.Logger, format, inputPath, outputPath string) error {
 	return engine.ConvertMock(ctx, logger, format, inputPath, outputPath)
+}
+
+func (engine PDFEngineMock) Compress(ctx context.Context, logger *zap.Logger, inputPath string, outputPath string) error {
+	return engine.CompressMock(ctx, logger, inputPath, outputPath)
 }
 
 // PDFEngineProviderMock is a mock for the PDFEngineProvider interface.

--- a/pkg/gotenberg/pdfengine.go
+++ b/pkg/gotenberg/pdfengine.go
@@ -38,6 +38,9 @@ type PDFEngine interface {
 
 	// Convert converts the given PDF to a specific PDF format.
 	Convert(ctx context.Context, logger *zap.Logger, format, inputPath, outputPath string) error
+
+	// Compress compress the given PDF
+	Compress(ctx context.Context, logger *zap.Logger, inputPath, outputPath string) error
 }
 
 // PDFEngineProvider is a module interface which exposes a method for creating a

--- a/pkg/modules/ghostscript/doc.go
+++ b/pkg/modules/ghostscript/doc.go
@@ -1,0 +1,3 @@
+// Package ghostscript provides a module which abstracts the CLI tool gs and
+// implements the gotenberg.PDFEngine interface.
+package ghostscript

--- a/pkg/modules/ghostscript/ghostscript.go
+++ b/pkg/modules/ghostscript/ghostscript.go
@@ -1,0 +1,128 @@
+package ghostscript
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/gotenberg/gotenberg/v7/pkg/gotenberg"
+	"go.uber.org/zap"
+)
+
+func init() {
+	gotenberg.MustRegisterModule(Ghostscript{})
+}
+
+// Ghostscript abstracts the CLI tool Ghostscript and implements the gotenberg.PDFEngine
+// interface.
+type Ghostscript struct {
+	binPath string
+}
+
+// Descriptor returns a Ghostscript's module descriptor.
+func (Ghostscript) Descriptor() gotenberg.ModuleDescriptor {
+	return gotenberg.ModuleDescriptor{
+		ID:  "ghostscript",
+		New: func() gotenberg.Module { return new(Ghostscript) },
+	}
+}
+
+// Provision sets the modules properties. It returns an error if the
+// environment variable GHOSTSCRIPT_BIN_PATH is not set.
+func (engine *Ghostscript) Provision(_ *gotenberg.Context) error {
+	binPath, ok := os.LookupEnv("GHOSTSCRIPT_BIN_PATH")
+	if !ok {
+		return errors.New("GHOSTSCRIPT_BIN_PATH environment variable is not set")
+	}
+
+	engine.binPath = binPath
+
+	return nil
+}
+
+// Validate validates the module properties.
+func (engine Ghostscript) Validate() error {
+	_, err := os.Stat(engine.binPath)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("Ghostscript binary path does not exist: %w", err)
+	}
+
+	return nil
+}
+
+// Metrics returns the metrics.
+func (engine Ghostscript) Metrics() ([]gotenberg.Metric, error) {
+	return []gotenberg.Metric{
+		{
+			Name:        "ghostscript_active_instances_count",
+			Description: "Current number of active Ghostscript instances.",
+			Read: func() float64 {
+				activeInstancesCountMu.RLock()
+				defer activeInstancesCountMu.RUnlock()
+
+				return activeInstancesCount
+			},
+		},
+	}, nil
+}
+
+// Merge is not available for this PDF engine.
+func (engine Ghostscript) Merge(ctx context.Context, logger *zap.Logger, inputPaths []string, outputPath string) error {
+	return fmt.Errorf("merge PDFs with Ghostscript: %w", gotenberg.ErrPDFEngineMethodNotAvailable)
+}
+
+// Convert is not available for this PDF engine.
+func (engine Ghostscript) Convert(_ context.Context, _ *zap.Logger, format, _, _ string) error {
+	return fmt.Errorf("convert PDF to '%s' with Ghostscript: %w", format, gotenberg.ErrPDFEngineMethodNotAvailable)
+}
+
+
+// Compress the given pdf
+func (engine Ghostscript) Compress(ctx context.Context, logger *zap.Logger, inputPath string, outputPath string) error {
+	var args []string
+	args = append(args, "-sDEVICE=pdfwrite")
+	args = append(args, "-dCompatibilityLevel=1.4")
+	args = append(args, "-dPDFSETTINGS=/screen")
+	args = append(args, "-dNOPAUSE")
+	args = append(args, "-dQUIET")
+	args = append(args, "-dBATCH")
+	args = append(args, "-sOutputFile=" + outputPath)
+	args = append(args, inputPath)
+
+	cmd, err := gotenberg.CommandContext(ctx, logger, engine.binPath, args...)
+	if err != nil {
+		return fmt.Errorf("create command: %w", err)
+	}
+
+	activeInstancesCountMu.Lock()
+	activeInstancesCount += 1
+	activeInstancesCountMu.Unlock()
+
+	_, err = cmd.Exec()
+
+	activeInstancesCountMu.Lock()
+	activeInstancesCount -= 1
+	activeInstancesCountMu.Unlock()
+
+	if err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("compress PDFs with Ghostscript: %w", err)
+}
+
+var (
+	activeInstancesCount   float64
+	activeInstancesCountMu sync.RWMutex
+)
+
+// Interface guards.
+var (
+	_ gotenberg.Module          = (*Ghostscript)(nil)
+	_ gotenberg.Provisioner     = (*Ghostscript)(nil)
+	_ gotenberg.Validator       = (*Ghostscript)(nil)
+	_ gotenberg.MetricsProvider = (*Ghostscript)(nil)
+	_ gotenberg.PDFEngine       = (*Ghostscript)(nil)
+)

--- a/pkg/modules/ghostscript/ghostscript_test.go
+++ b/pkg/modules/ghostscript/ghostscript_test.go
@@ -1,0 +1,97 @@
+package ghostscript
+
+import (
+	"context"
+	"errors"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/gotenberg/gotenberg/v7/pkg/gotenberg"
+	"go.uber.org/zap"
+)
+
+func TestGhostscript_Descriptor(t *testing.T) {
+	descriptor := Ghostscript{}.Descriptor()
+
+	actual := reflect.TypeOf(descriptor.New())
+	expect := reflect.TypeOf(new(Ghostscript))
+
+	if actual != expect {
+		t.Errorf("expected '%s' but got '%s'", expect, actual)
+	}
+}
+
+func TestGhostscript_Provision(t *testing.T) {
+	mod := new(Ghostscript)
+	ctx := gotenberg.NewContext(gotenberg.ParsedFlags{}, nil)
+
+	err := mod.Provision(ctx)
+	if err != nil {
+		t.Errorf("expected no error but got: %v", err)
+	}
+}
+
+func TestGhostscript_Validate(t *testing.T) {
+	for i, tc := range []struct {
+		binPath   string
+		expectErr bool
+	}{
+		{
+			expectErr: true,
+		},
+		{
+			binPath:   "/foo",
+			expectErr: true,
+		},
+		{
+			binPath: os.Getenv("GHOSTSCRIPT_BIN_PATH"),
+		},
+	} {
+		mod := new(Ghostscript)
+		mod.binPath = tc.binPath
+		err := mod.Validate()
+
+		if tc.expectErr && err == nil {
+			t.Errorf("test %d: expected error but got: %v", i, err)
+		}
+
+		if !tc.expectErr && err != nil {
+			t.Errorf("test %d: expected no error but got: %v", i, err)
+		}
+	}
+}
+
+func TestGhostscript_Metrics(t *testing.T) {
+	metrics, err := new(Ghostscript).Metrics()
+	if err != nil {
+		t.Fatalf("expected no error but got: %v", err)
+	}
+
+	if len(metrics) != 1 {
+		t.Fatalf("expected %d metrics, but got %d", 1, len(metrics))
+	}
+
+	actual := metrics[0].Read()
+	if actual != 0 {
+		t.Errorf("expected %d Ghostscript instances, but got %f", 0, actual)
+	}
+}
+
+func TestGhostscript_Merge(t *testing.T) {
+	mod := new(Ghostscript)
+	err := mod.Convert(context.TODO(), zap.NewNop(), "", "", "")
+
+	if !errors.Is(err, gotenberg.ErrPDFEngineMethodNotAvailable) {
+		t.Errorf("expected error %v, but got: %v", gotenberg.ErrPDFEngineMethodNotAvailable, err)
+	}
+}
+
+func TestGhostscript_Convert(t *testing.T) {
+	mod := new(Ghostscript)
+	err := mod.Convert(context.TODO(), zap.NewNop(), "", "", "")
+
+	if !errors.Is(err, gotenberg.ErrPDFEngineMethodNotAvailable) {
+		t.Errorf("expected error %v, but got: %v", gotenberg.ErrPDFEngineMethodNotAvailable, err)
+	}
+}

--- a/pkg/modules/libreoffice/pdfengine/pdfengine.go
+++ b/pkg/modules/libreoffice/pdfengine/pdfengine.go
@@ -69,6 +69,11 @@ func (engine UNO) Convert(ctx context.Context, logger *zap.Logger, format, input
 	return fmt.Errorf("convert PDF to '%s' with unoconv: %w", format, err)
 }
 
+// Compress is not available for this PDF engine.
+func (engine UNO) Compress(_ context.Context, _ *zap.Logger, _ string, _ string) error {
+	return fmt.Errorf("compress PDF with unoconv: %w", gotenberg.ErrPDFEngineMethodNotAvailable)
+}
+
 // Interface guards.
 var (
 	_ gotenberg.Module      = (*UNO)(nil)

--- a/pkg/modules/pdfcpu/pdfcpu.go
+++ b/pkg/modules/pdfcpu/pdfcpu.go
@@ -54,6 +54,11 @@ func (engine PDFcpu) Convert(_ context.Context, _ *zap.Logger, format, _, _ stri
 	return fmt.Errorf("convert PDF to '%s' with PDFcpu: %w", format, gotenberg.ErrPDFEngineMethodNotAvailable)
 }
 
+// Compress is not available for this PDF engine.
+func (engine PDFcpu) Compress(_ context.Context, _ *zap.Logger, _ string, _ string) error {
+	return fmt.Errorf("compress PDF with PDFcpu: %w", gotenberg.ErrPDFEngineMethodNotAvailable)
+}
+
 // Interface guards.
 var (
 	_ gotenberg.Module      = (*PDFcpu)(nil)

--- a/pkg/modules/pdfengines/multi.go
+++ b/pkg/modules/pdfengines/multi.go
@@ -87,7 +87,7 @@ func (multi multiPDFEngines) Compress(ctx context.Context, logger *zap.Logger, i
 		}(engine)
 
 		select {
-		case mergeErr := <-errChan:
+		case compressErr := <-errChan:
 			errored := multierr.AppendInto(&err, mergeErr)
 			if !errored {
 				return nil

--- a/pkg/modules/pdfengines/pdfengines.go
+++ b/pkg/modules/pdfengines/pdfengines.go
@@ -178,6 +178,7 @@ func (mod PDFEngines) Routes() ([]api.Route, error) {
 	return []api.Route{
 		mergeRoute(engine),
 		convertRoute(engine),
+		compressRoute(engine),
 	}, nil
 }
 

--- a/pkg/modules/pdftk/pdftk.go
+++ b/pkg/modules/pdftk/pdftk.go
@@ -101,6 +101,11 @@ func (engine PDFtk) Convert(_ context.Context, _ *zap.Logger, format, _, _ strin
 	return fmt.Errorf("convert PDF to '%s' with PDFtk: %w", format, gotenberg.ErrPDFEngineMethodNotAvailable)
 }
 
+// Compress is not available for this PDF engine.
+func (engine PDFtk) Compress(_ context.Context, _ *zap.Logger, _ string, _ string) error {
+	return fmt.Errorf("compress PDF with PDFtk: %w", gotenberg.ErrPDFEngineMethodNotAvailable)
+}
+
 var (
 	activeInstancesCount   float64
 	activeInstancesCountMu sync.RWMutex

--- a/pkg/modules/qpdf/qpdf.go
+++ b/pkg/modules/qpdf/qpdf.go
@@ -103,6 +103,11 @@ func (engine QPDF) Convert(_ context.Context, _ *zap.Logger, format, _, _ string
 	return fmt.Errorf("convert PDF to '%s' with QPDF: %w", format, gotenberg.ErrPDFEngineMethodNotAvailable)
 }
 
+// Compress is not available for this PDF engine.
+func (engine QPDF) Compress(_ context.Context, _ *zap.Logger, _ string, _ string) error {
+	return fmt.Errorf("compress PDF with QPDF: %w", gotenberg.ErrPDFEngineMethodNotAvailable)
+}
+
 var (
 	activeInstancesCount   float64
 	activeInstancesCountMu sync.RWMutex

--- a/pkg/standard/imports.go
+++ b/pkg/standard/imports.go
@@ -15,4 +15,5 @@ import (
 	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/prometheus"
 	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/qpdf"
 	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/webhook"
+	_ "github.com/gotenberg/gotenberg/v7/pkg/modules/ghostscript"
 )


### PR DESCRIPTION
This endpoint allow to compress a pdf.
This can help a lot for chromium pdf export that can have large output.

*Back story*: we were having some issue (https://bugs.chromium.org/p/chromium/issues/detail?id=103602) and found that for one generated PDF from chromium/gotenberg was about 1.8MB. It can go down to 225KB by compressing it with ghostscript.

This include a new pdfengines/compress route, a new ghostscript pdfengine that implements it.

What do you think about a such new feature ?
Is is the right way to go ?

## Benchmark

All generated/compressed files gave us no visual difference on linux and windows/acrobat (mac not tested). We have an PDF named `initial.pdf`, and 3 tests:
```
$ ps2pdf initial.pdf output-1.pdf
$ ps2pdf -dPDFSETTINGS=/ebook initial.pdf output-2.pdf
$ gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/screen -dNOPAUSE -dQUIET -dBATCH -sOutputFile=output-3.pdf initial.pdf
$ ls -lah *.pdf
-rw-r--r-- 1 tito tito 1,8M 15 févr. 14:11 initial.pdf
-rw-r--r-- 1 tito tito 425K 15 févr. 14:12 output-1.pdf
-rw-r--r-- 1 tito tito 374K 15 févr. 14:12 output-2.pdf
-rw-r--r-- 1 tito tito 225K 15 févr. 14:13 output-3.pdf
```
