### PR TITLE
Implement document thumbnailing

### DIFF
--- a/pkg/modules/libreoffice/libreoffice.go
+++ b/pkg/modules/libreoffice/libreoffice.go
@@ -75,6 +75,7 @@ func (mod LibreOffice) Routes() ([]api.Route, error) {
 
 	return []api.Route{
 		convertRoute(mod.unoAPI, mod.engine),
+		thumbnailRoute(mod.unoAPI, mod.engine),
 	}, nil
 }
 

--- a/pkg/modules/libreoffice/uno/mocks.go
+++ b/pkg/modules/libreoffice/uno/mocks.go
@@ -9,11 +9,16 @@ import (
 // APIMock is a mock for the API interface.
 type APIMock struct {
 	PDFMock        func(ctx context.Context, logger *zap.Logger, inputPath, outputPath string, options Options) error
+	ThumbnailMock  func(ctx context.Context, logger *zap.Logger, inputPath, outputPath string, outputExtension string) error
 	ExtensionsMock func() []string
 }
 
 func (api APIMock) PDF(ctx context.Context, logger *zap.Logger, inputPath, outputPath string, options Options) error {
 	return api.PDFMock(ctx, logger, inputPath, outputPath, options)
+}
+
+func (api APIMock) Thumbnail(ctx context.Context, logger *zap.Logger, inputPath, outputPath string, outputExtension string) error {
+	return api.ThumbnailMock(ctx, logger, inputPath, outputPath, outputExtension)
 }
 
 func (api APIMock) Extensions() []string {

--- a/pkg/modules/libreoffice/uno/uno.go
+++ b/pkg/modules/libreoffice/uno/uno.go
@@ -61,6 +61,7 @@ type Options struct {
 // API is an abstraction on top of uno.
 type API interface {
 	PDF(ctx context.Context, logger *zap.Logger, inputPath, outputPath string, options Options) error
+	Thumbnail(ctx context.Context, logger *zap.Logger, inputPath, outputPath string, outputExtension string) error
 	Extensions() []string
 }
 
@@ -403,6 +404,97 @@ func (mod UNO) PDF(ctx context.Context, logger *zap.Logger, inputPath, outputPat
 	// of its temporary files, as it has been killed without warning. The
 	// garbage collector will delete them for us (if the module is loaded).
 	return fmt.Errorf("unoconv PDF: %w", err)
+}
+
+// Thumbnail converts the first page of a document to the supplied image format.
+//
+// If there is no long-running LibreOffice listener, it creates a dedicated
+// LibreOffice instance for the conversion. Substantial calls to this method
+// may increase CPU and memory usage drastically
+//
+// If there is a long-running LibreOffice listener, the conversion performance
+// improves substantially. However, it cannot perform parallel operations.
+func (mod UNO) Thumbnail(ctx context.Context, logger *zap.Logger, inputPath, outputPath string, outputExtension string) error {
+	args := []string{
+		"--no-launch",
+		"--format",
+		outputExtension,
+	}
+
+	switch mod.libreOfficeRestartThreshold {
+	case 0:
+		listener := newLibreOfficeListener(logger, mod.libreOfficeBinPath, mod.libreOfficeStartTimeout, 0)
+
+		err := listener.start(logger)
+		if err != nil {
+			return fmt.Errorf("start LibreOffice listener: %w", err)
+		}
+
+		defer func() {
+			err := listener.stop(logger)
+			if err != nil {
+				logger.Error(fmt.Sprintf("stop LibreOffice listener: %v", err))
+			}
+		}()
+
+		args = append(args, "--port", fmt.Sprintf("%d", listener.port()))
+	default:
+		err := mod.listener.lock(ctx, logger)
+		if err != nil {
+			return fmt.Errorf("lock long-running LibreOffice listener: %w", err)
+		}
+
+		defer func() {
+			go func() {
+				err := mod.listener.unlock(logger)
+				if err != nil {
+					mod.logger.Error(fmt.Sprintf("unlock long-running LibreOffice listener: %v", err))
+
+					return
+				}
+			}()
+		}()
+
+		// If the LibreOffice listener is restarting while acquiring the lock,
+		// the port will change. It's therefore important to add the port args
+		// after we acquire the lock.
+		args = append(args, "--port", fmt.Sprintf("%d", mod.listener.port()))
+	}
+
+	checkedEntry := logger.Check(zap.DebugLevel, "check for debug level before setting high verbosity")
+	if checkedEntry != nil {
+		args = append(args, "-vvv")
+	}
+
+	args = append(args, "--output", outputPath, inputPath)
+
+	cmd, err := gotenberg.CommandContext(ctx, logger, mod.unoconvBinPath, args...)
+	if err != nil {
+		return fmt.Errorf("create unoconv command: %w", err)
+	}
+
+	activeInstancesCountMu.Lock()
+	activeInstancesCount += 1
+	activeInstancesCountMu.Unlock()
+
+	exitCode, err := cmd.Exec()
+
+	activeInstancesCountMu.Lock()
+	activeInstancesCount -= 1
+	activeInstancesCountMu.Unlock()
+
+	if err == nil {
+		return nil
+	}
+
+	// Possible errors:
+	// 1. Unoconv/LibreOffice failed for some reason.
+	// 2. Context done.
+	//
+	// On the second scenario, LibreOffice might not have time to remove some
+	// of its temporary files, as it has been killed without warning. The
+	// garbage collector will delete them for us (if the module is loaded).
+	return fmt.Errorf("unoconv JPG: %w, %v", err, exitCode)
 }
 
 // Extensions returns the file extensions available for conversions.


### PR DESCRIPTION
This implements a new route at /forms/libreoffice/thumbnail for the purposes of "thumbnailing" the first page of a document format.
It takes a single imageFormat parameter, allowing conversion of a docx/pdf to jpg/tiff/png etc...

If you're willing to accept, I will also add some unit tests, or do some suggested refactoring