### PR TITLE
add encrypt route

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -355,6 +355,75 @@ paths:
         '400':
           description: >-
             Bad Request, e.g. Invalid form data: no form file found for extensions: [.pdf]; form value 'pdfFormat' is required
+            
+  /forms/pdfengines/encrypt:
+    post:
+      tags:
+        - pdfengines
+      summary: Encrypts PDFs with given passwords
+      externalDocs:
+        url: https://gotenberg.dev/docs/modules/pdf-engines
+      description: >-
+        This route accepts PDF files and a form field pdfFormat for converting them into the specified format.
+      parameters:
+        - in: header
+          name: Gotenberg-Output-Filename
+          description: >-
+            By default, the API generates a UUID filename.
+            However, you may also specify the filename per request,
+            thanks to the Gotenberg-Output-Filename header.
+            Caution! The API adds the file extension automatically; you don't have to set it.
+          schema:
+            type: string
+          required: false
+        - in: header
+          name: Gotenberg-Trace
+          description: >-
+            The trace, or request ID, identifies a request in the logs.
+
+            By default, the API generates a UUID trace for each request.
+            However, you may also specify the trace per request, thanks to the Gotenberg-Trace header.
+          schema:
+            type: string
+          required: false
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+                ownerPassword:
+                  type: string
+                  description: The Password used for permissions.
+                  example: secureOwnerPassword
+                userPassword:
+                  type: string
+                  description: The Password used for access to the PDF
+                  example: secureUserPassword
+                keyLength:
+                  type: integer
+                  description: Keylength for encryption, defaults to 256
+                  enum: 
+                   - 40
+                   - 128
+                   - 256
+                  example: 256
+              required:
+                - files
+                - ownerPassword
+                - userPassword
+
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessfulPDF'
+        '400':
+          description: >-
+            Bad Request, e.g. Invalid form data: no form file found for extensions: [.pdf]; form value 'ownerPassword' is required; form value 'userPassword' is required;
 
 components:
   schemas:

--- a/pkg/gotenberg/mocks.go
+++ b/pkg/gotenberg/mocks.go
@@ -28,6 +28,7 @@ func (mod ValidatorMock) Validate() error {
 type PDFEngineMock struct {
 	MergeMock   func(ctx context.Context, logger *zap.Logger, inputPaths []string, outputPath string) error
 	ConvertMock func(ctx context.Context, logger *zap.Logger, format, inputPath, outputPath string) error
+	EncryptMock func(ctx context.Context, logger *zap.Logger, keyLength int, ownerPassword, userPassword, inputPath, outputPath string) error
 }
 
 func (engine PDFEngineMock) Merge(ctx context.Context, logger *zap.Logger, inputPaths []string, outputPath string) error {
@@ -36,6 +37,10 @@ func (engine PDFEngineMock) Merge(ctx context.Context, logger *zap.Logger, input
 
 func (engine PDFEngineMock) Convert(ctx context.Context, logger *zap.Logger, format, inputPath, outputPath string) error {
 	return engine.ConvertMock(ctx, logger, format, inputPath, outputPath)
+}
+
+func (engine PDFEngineMock) Encrypt(ctx context.Context, logger *zap.Logger, keyLength int, ownerPassword, userPassword, inputPath, outputPath string) error {
+	return engine.EncryptMock(ctx, logger, keyLength, ownerPassword, userPassword, inputPath, outputPath)
 }
 
 // PDFEngineProviderMock is a mock for the PDFEngineProvider interface.

--- a/pkg/gotenberg/pdfengine.go
+++ b/pkg/gotenberg/pdfengine.go
@@ -38,6 +38,9 @@ type PDFEngine interface {
 
 	// Convert converts the given PDF to a specific PDF format.
 	Convert(ctx context.Context, logger *zap.Logger, format, inputPath, outputPath string) error
+
+	//Encrypt one or more PDF Files with given passwords.
+	Encrypt(ctx context.Context, logger *zap.Logger, keyLength int, ownerPassword, userPassword, inputPath, outputPath string) error
 }
 
 // PDFEngineProvider is a module interface which exposes a method for creating a

--- a/pkg/modules/chromium/chromium_test.go
+++ b/pkg/modules/chromium/chromium_test.go
@@ -41,6 +41,7 @@ func (mod ProtoPDFEngineProvider) PDFEngine() (gotenberg.PDFEngine, error) {
 type ProtoPDFEngine struct {
 	merge   func(_ context.Context, _ *zap.Logger, _ []string, _ string) error
 	convert func(_ context.Context, _ *zap.Logger, _, _, _ string) error
+	encrypt func(_ context.Context, _ *zap.Logger, _ int, _, _, _, _ string) error
 }
 
 func (mod ProtoPDFEngine) Merge(ctx context.Context, logger *zap.Logger, inputPaths []string, outputPath string) error {
@@ -49,6 +50,10 @@ func (mod ProtoPDFEngine) Merge(ctx context.Context, logger *zap.Logger, inputPa
 
 func (mod ProtoPDFEngine) Convert(ctx context.Context, logger *zap.Logger, format, inputPath, outputPath string) error {
 	return mod.convert(ctx, logger, format, inputPath, outputPath)
+}
+
+func (mod ProtoPDFEngine) Encrypt(ctx context.Context, logger *zap.Logger, keyLength int, ownerPassword, userPassword, inputPath, outputPath string) error {
+	return mod.encrypt(ctx, logger, keyLength, ownerPassword, userPassword, inputPath, outputPath)
 }
 
 func TestDefaultOptions(t *testing.T) {

--- a/pkg/modules/libreoffice/pdfengine/pdfengine.go
+++ b/pkg/modules/libreoffice/pdfengine/pdfengine.go
@@ -69,6 +69,11 @@ func (engine UNO) Convert(ctx context.Context, logger *zap.Logger, format, input
 	return fmt.Errorf("convert PDF to '%s' with unoconv: %w", format, err)
 }
 
+// Encrypt is not available for this PDF engine.
+func (engine UNO) Encrypt(_ context.Context, _ *zap.Logger, _ int, _, _ , _ , _ string) error {
+	return fmt.Errorf("encrypt PDF with unoconv: %w", gotenberg.ErrPDFEngineMethodNotAvailable)
+}
+
 // Interface guards.
 var (
 	_ gotenberg.Module      = (*UNO)(nil)

--- a/pkg/modules/pdfcpu/pdfcpu.go
+++ b/pkg/modules/pdfcpu/pdfcpu.go
@@ -54,6 +54,22 @@ func (engine PDFcpu) Convert(_ context.Context, _ *zap.Logger, format, _, _ stri
 	return fmt.Errorf("convert PDF to '%s' with PDFcpu: %w", format, gotenberg.ErrPDFEngineMethodNotAvailable)
 }
 
+func (engine PDFcpu) Encrypt(_ context.Context, _ *zap.Logger, keyLength int, ownerPassword, userPassword, inputPath, outputPath string) error {
+	conf := engine.conf
+	
+	conf.EncryptKeyLength = keyLength
+	conf.UserPW = userPassword
+	conf.OwnerPW = ownerPassword
+
+	err := pdfcpuAPI.EncryptFile(inputPath, outputPath, conf)
+	
+	if err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("encrypt PDF with PDFcpu: %w", err)
+}
+
 // Interface guards.
 var (
 	_ gotenberg.Module      = (*PDFcpu)(nil)

--- a/pkg/modules/pdfengines/pdfengines.go
+++ b/pkg/modules/pdfengines/pdfengines.go
@@ -178,6 +178,7 @@ func (mod PDFEngines) Routes() ([]api.Route, error) {
 	return []api.Route{
 		mergeRoute(engine),
 		convertRoute(engine),
+		encryptRoute(engine),
 	}, nil
 }
 

--- a/pkg/modules/pdfengines/pdfengines_test.go
+++ b/pkg/modules/pdfengines/pdfengines_test.go
@@ -420,7 +420,7 @@ func TestPDFEngines_Routes(t *testing.T) {
 					gotenberg.PDFEngineMock{},
 				},
 			},
-			expectRoutesCount: 2,
+			expectRoutesCount: 3,
 		},
 		{
 			name: "route disabled",

--- a/pkg/modules/pdftk/pdftk.go
+++ b/pkg/modules/pdftk/pdftk.go
@@ -101,6 +101,10 @@ func (engine PDFtk) Convert(_ context.Context, _ *zap.Logger, format, _, _ strin
 	return fmt.Errorf("convert PDF to '%s' with PDFtk: %w", format, gotenberg.ErrPDFEngineMethodNotAvailable)
 }
 
+func (engine PDFtk) Encrypt(ctx context.Context, logger *zap.Logger, keyLength int, ownerPassword, userPassword, inputPath, outputPath string) error {
+	return fmt.Errorf("encrypt PDF with PDFtk: %w", gotenberg.ErrPDFEngineMethodNotAvailable)
+}
+
 var (
 	activeInstancesCount   float64
 	activeInstancesCountMu sync.RWMutex


### PR DESCRIPTION
First time even touching go. Implemented encryption of PDFs for qpdf and pdfcpu. Pdftk also supports encrypting, but behaviour was weird, so i dropped it for now. 

Api description was extended, but no tests so far, because i have no idea how they work in go. 

Please give feedback :)