### PR TITLE
fix(webhook/client): error on http status codes >= 400

### DIFF
--- a/pkg/modules/webhook/client.go
+++ b/pkg/modules/webhook/client.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"fmt"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -76,6 +77,10 @@ func (c client) send(body io.Reader, headers map[string]string, erroed bool) err
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("send '%s' request to '%s': %w", method, URL, err)
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("send '%s' request to '%s': got status: '%s'", method, URL, resp.Status)
 	}
 
 	defer func() {


### PR DESCRIPTION
As dicussed in https://github.com/gotenberg/gotenberg/issues/550 this change catches an http response code >=400 to ensure it the caller of the send function can handle it (in this case by logging it).