### PR TITLE
added keepMergeOrder functionality

### DIFF
--- a/pkg/modules/api/context.go
+++ b/pkg/modules/api/context.go
@@ -204,6 +204,13 @@ func (ctx Context) GeneratePath(extension string) string {
 	return fmt.Sprintf("%s/%s%s", ctx.dirPath, uuid.New(), extension)
 }
 
+// GeneratePathOrdered generates a path within the context's working directory
+// and keeps the original files order. It does not create a file.
+
+func (ctx Context) GeneratePathOrdered(extension string, i int) string {
+	return fmt.Sprintf("%s/%d_%s%s", ctx.dirPath, i, uuid.New(), extension)
+}
+
 // AddOutputPaths adds the given paths. Those paths will be used later to build
 // the output file.
 func (ctx *Context) AddOutputPaths(paths ...string) error {

--- a/pkg/modules/libreoffice/routes.go
+++ b/pkg/modules/libreoffice/routes.go
@@ -30,6 +30,7 @@ func convertRoute(unoAPI uno.API, engine gotenberg.PDFEngine) api.Route {
 				nativePDFformat    string
 				PDFformat          string
 				merge              bool
+				keepMergeOrder	   bool
 			)
 
 			err := ctx.FormData().
@@ -40,6 +41,7 @@ func convertRoute(unoAPI uno.API, engine gotenberg.PDFEngine) api.Route {
 				String("nativePdfFormat", &nativePDFformat, "").
 				String("pdfFormat", &PDFformat, "").
 				Bool("merge", &merge, false).
+				Bool("keepMergeOrder", &keepMergeOrder, false).
 				Validate()
 
 			if err != nil {
@@ -80,7 +82,11 @@ func convertRoute(unoAPI uno.API, engine gotenberg.PDFEngine) api.Route {
 			outputPaths := make([]string, len(inputPaths))
 
 			for i, inputPath := range inputPaths {
-				outputPaths[i] = ctx.GeneratePath(".pdf")
+				if keepMergeOrder {
+					outputPaths[i] = ctx.GeneratePathOrdered(".pdf", i)
+				} else {
+					outputPaths[i] = ctx.GeneratePath(".pdf")
+				}
 
 				options := uno.Options{
 					Landscape:  landscape,


### PR DESCRIPTION
Added functionality to keep files order when converting from word to PDF and merging.

To enable this functionality added a new method for generating file output path that prefixes a counter with uuid for filename.