### PR TITLE
Address critical vuln in `debian:11-slim` 

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -30,7 +30,7 @@ RUN go build -o gotenberg -ldflags "-X 'github.com/gotenberg/gotenberg/v7/cmd.Ve
 # ----------------------------------------------
 # Final stage
 # ----------------------------------------------
-FROM debian:11-slim
+FROM debian:bookworm-20230725-slim
 
 ARG GOTENBERG_VERSION
 ARG GOTENBERG_USER_GID


### PR DESCRIPTION
Our security scanning tooling flagged that Gottenberg has a critical vulnerability because of it's use of `debian:11-slim`. This change bumps the base image to the latest non-vulnerable version.

The critical CVE is https://www.cve.org/CVERecord?id=CVE-2021-32292