### PR TITLE
Added org.opencontainers.image.source label to allow dependabot pull release notes

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -42,7 +42,8 @@ LABEL author="Julien Neuhart" \
       description="A Docker-powered stateless API for PDF files." \
       github="https://github.com/gotenberg/gotenberg" \
       version="$GOTENBERG_VERSION" \
-      website="https://gotenberg.dev"
+      website="https://gotenberg.dev" \
+      org.opencontainers.image.source="https://github.com/gotenberg/gotenberg"
 
 RUN \
     # Create a non-root user.


### PR DESCRIPTION
Dependabot uses the `org.opencontainers.image.source` label to fetch release notes, changelogs and commit history for docker images as per https://github.blog/changelog/2023-04-13-dependabot-now-supports-fetching-release-notes-and-changelogs-for-docker-images/

The label is also a standard name for opencontainers as per https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys