### PR TITLE
fix(libreoffice): accept PDF/A-1b instead of PDF/A-1a

### DIFF
--- a/pkg/modules/chromium/routes_test.go
+++ b/pkg/modules/chromium/routes_test.go
@@ -702,7 +702,7 @@ func TestConvertUrl(t *testing.T) {
 			engine: &gotenberg.PdfEngineMock{ConvertMock: func(ctx context.Context, logger *zap.Logger, formats gotenberg.PdfFormats, inputPath, outputPath string) error {
 				return nil
 			}},
-			pdfFormats:             gotenberg.PdfFormats{PdfA: gotenberg.PdfA1a},
+			pdfFormats:             gotenberg.PdfFormats{PdfA: gotenberg.PdfA1b},
 			options:                DefaultOptions(),
 			expectError:            false,
 			expectHttpError:        false,

--- a/pkg/modules/libreoffice/api/api.go
+++ b/pkg/modules/libreoffice/api/api.go
@@ -50,7 +50,7 @@ type Options struct {
 	// Optional.
 	PageRanges string
 
-	// PdfFormats allows to convert the resulting PDF to PDF/A-1a, PDF/A-2b,
+	// PdfFormats allows to convert the resulting PDF to PDF/A-1b, PDF/A-2b,
 	// PDF/A-3b and PDF/UA.
 	// Optional.
 	PdfFormats gotenberg.PdfFormats

--- a/pkg/modules/libreoffice/api/libreoffice.go
+++ b/pkg/modules/libreoffice/api/libreoffice.go
@@ -275,7 +275,7 @@ func (p *libreOfficeProcess) pdf(ctx context.Context, logger *zap.Logger, inputP
 
 	switch options.PdfFormats.PdfA {
 	case "":
-	case gotenberg.PdfA1a:
+	case gotenberg.PdfA1b:
 		args = append(args, "--export", "SelectPdfVersion=1")
 	case gotenberg.PdfA2b:
 		args = append(args, "--export", "SelectPdfVersion=2")

--- a/pkg/modules/libreoffice/api/libreoffice_test.go
+++ b/pkg/modules/libreoffice/api/libreoffice_test.go
@@ -394,7 +394,7 @@ func TestLibreOfficeProcess_pdf(t *testing.T) {
 			expectError:  false,
 		},
 		{
-			scenario: "success (PDF/A-1a)",
+			scenario: "success (PDF/A-1b)",
 			libreOffice: newLibreOfficeProcess(
 				libreOfficeArguments{
 					binPath:      os.Getenv("LIBREOFFICE_BIN_PATH"),
@@ -417,7 +417,7 @@ func TestLibreOfficeProcess_pdf(t *testing.T) {
 
 				return fs
 			}(),
-			options:      Options{PdfFormats: gotenberg.PdfFormats{PdfA: gotenberg.PdfA1a}},
+			options:      Options{PdfFormats: gotenberg.PdfFormats{PdfA: gotenberg.PdfA1b}},
 			cancelledCtx: false,
 			start:        true,
 			expectError:  false,

--- a/pkg/modules/libreoffice/pdfengine/pdfengine.go
+++ b/pkg/modules/libreoffice/pdfengine/pdfengine.go
@@ -52,7 +52,7 @@ func (engine *LibreOfficePdfEngine) Merge(ctx context.Context, logger *zap.Logge
 }
 
 // Convert converts the given PDF to a specific PDF format. Currently, only the
-// PDF/A-1a, PDF/A-2b, PDF/A-3b and PDF/UA formats are available. If another
+// PDF/A-1b, PDF/A-2b, PDF/A-3b and PDF/UA formats are available. If another
 // PDF format is requested, it returns a [gotenberg.ErrPdfFormatNotSupported]
 // error.
 func (engine *LibreOfficePdfEngine) Convert(ctx context.Context, logger *zap.Logger, formats gotenberg.PdfFormats, inputPath, outputPath string) error {

--- a/pkg/modules/libreoffice/routes_test.go
+++ b/pkg/modules/libreoffice/routes_test.go
@@ -124,7 +124,7 @@ func TestConvertRoute(t *testing.T) {
 				})
 				ctx.SetValues(map[string][]string{
 					"pdfa": {
-						gotenberg.PdfA1a,
+						gotenberg.PdfA1b,
 					},
 					"nativePdfFormats": {
 						"false",
@@ -223,7 +223,7 @@ func TestConvertRoute(t *testing.T) {
 				})
 				ctx.SetValues(map[string][]string{
 					"pdfa": {
-						gotenberg.PdfA1a,
+						gotenberg.PdfA1b,
 					},
 					"pdfua": {
 						"true",
@@ -260,7 +260,7 @@ func TestConvertRoute(t *testing.T) {
 				})
 				ctx.SetValues(map[string][]string{
 					"pdfa": {
-						gotenberg.PdfA1a,
+						gotenberg.PdfA1b,
 					},
 					"pdfua": {
 						"true",
@@ -372,7 +372,7 @@ func TestConvertRoute(t *testing.T) {
 						"true",
 					},
 					"pdfa": {
-						gotenberg.PdfA1a,
+						gotenberg.PdfA1b,
 					},
 					"nativePdfFormats": {
 						"false",
@@ -478,7 +478,7 @@ func TestConvertRoute(t *testing.T) {
 						"true",
 					},
 					"pdfa": {
-						gotenberg.PdfA1a,
+						gotenberg.PdfA1b,
 					},
 					"pdfua": {
 						"true",
@@ -522,7 +522,7 @@ func TestConvertRoute(t *testing.T) {
 						"true",
 					},
 					"pdfa": {
-						gotenberg.PdfA1a,
+						gotenberg.PdfA1b,
 					},
 					"pdfua": {
 						"true",

--- a/pkg/modules/pdfengines/routes_test.go
+++ b/pkg/modules/pdfengines/routes_test.go
@@ -99,7 +99,7 @@ func TestMergeHandler(t *testing.T) {
 				})
 				ctx.SetValues(map[string][]string{
 					"pdfa": {
-						gotenberg.PdfA1a,
+						gotenberg.PdfA1b,
 					},
 				})
 				return ctx
@@ -127,7 +127,7 @@ func TestMergeHandler(t *testing.T) {
 				})
 				ctx.SetValues(map[string][]string{
 					"pdfa": {
-						gotenberg.PdfA1a,
+						gotenberg.PdfA1b,
 					},
 				})
 				return ctx
@@ -154,7 +154,7 @@ func TestMergeHandler(t *testing.T) {
 				})
 				ctx.SetValues(map[string][]string{
 					"pdfa": {
-						gotenberg.PdfA1a,
+						gotenberg.PdfA1b,
 					},
 					"pdfua": {
 						"true",
@@ -256,7 +256,7 @@ func TestConvertHandler(t *testing.T) {
 				})
 				ctx.SetValues(map[string][]string{
 					"pdfa": {
-						gotenberg.PdfA1a,
+						gotenberg.PdfA1b,
 					},
 				})
 				return ctx
@@ -280,7 +280,7 @@ func TestConvertHandler(t *testing.T) {
 				})
 				ctx.SetValues(map[string][]string{
 					"pdfa": {
-						gotenberg.PdfA1a,
+						gotenberg.PdfA1b,
 					},
 				})
 				return ctx
@@ -303,7 +303,7 @@ func TestConvertHandler(t *testing.T) {
 				})
 				ctx.SetValues(map[string][]string{
 					"pdfa": {
-						gotenberg.PdfA1a,
+						gotenberg.PdfA1b,
 					},
 				})
 				ctx.SetCancelled(true)
@@ -327,7 +327,7 @@ func TestConvertHandler(t *testing.T) {
 				})
 				ctx.SetValues(map[string][]string{
 					"pdfa": {
-						gotenberg.PdfA1a,
+						gotenberg.PdfA1b,
 					},
 					"pdfua": {
 						"true",
@@ -354,7 +354,7 @@ func TestConvertHandler(t *testing.T) {
 				})
 				ctx.SetValues(map[string][]string{
 					"pdfa": {
-						gotenberg.PdfA1a,
+						gotenberg.PdfA1b,
 					},
 					"pdfua": {
 						"true",


### PR DESCRIPTION
Fixes #746.

Long story short, LibreOffice stated that it was producing PDF/A-1a PDF, which was true for simple documents, but most of the time it was actually producing PDF/A-1b. Because of some metadata, some validators were still seeing those as PDF/A-1a compliant, where in fact it was not the case.

⚠️ breaking change