### PR TITLE
feat(chromium): return 409 Conflict if HTTP status code from main page is not acceptable

### DIFF
--- a/pkg/modules/chromium/browser_test.go
+++ b/pkg/modules/chromium/browser_test.go
@@ -416,6 +416,39 @@ func TestChromiumBrowser_pdf(t *testing.T) {
 			},
 		},
 		{
+			scenario: "ErrInvalidHttpStatusCode",
+			browser: newChromiumBrowser(
+				browserArguments{
+					binPath:          os.Getenv("CHROMIUM_BIN_PATH"),
+					wsUrlReadTimeout: 5 * time.Second,
+					allowList:        regexp.MustCompile(""),
+					denyList:         regexp.MustCompile(""),
+				},
+			),
+			fs: func() *gotenberg.FileSystem {
+				fs := gotenberg.NewFileSystem()
+
+				err := os.MkdirAll(fs.WorkingDirPath(), 0o755)
+				if err != nil {
+					t.Fatalf(fmt.Sprintf("expected no error but got: %v", err))
+				}
+
+				err = os.WriteFile(fmt.Sprintf("%s/index.html", fs.WorkingDirPath()), []byte("<h1>ErrInvalidHttpStatusCode</h1>"), 0o755)
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+
+				return fs
+			}(),
+			options: Options{
+				FailOnHttpStatusCodes: []int64{299},
+			},
+			noDeadline:    false,
+			start:         true,
+			expectError:   true,
+			expectedError: ErrInvalidHttpStatusCode,
+		},
+		{
 			scenario: "ErrConsoleExceptions",
 			browser: newChromiumBrowser(
 				browserArguments{

--- a/pkg/modules/chromium/chromium.go
+++ b/pkg/modules/chromium/chromium.go
@@ -48,6 +48,10 @@ var (
 	// ChromeDevTools are larger than 100 MB.
 	ErrRpccMessageTooLarge = errors.New("rpcc message too large")
 
+	// ErrInvalidHttpStatusCode happens when the status code from the main page
+	// matches with one of the entry in [Options.FailOnHttpStatusCodes].
+	ErrInvalidHttpStatusCode = errors.New("invalid HTTP status code")
+
 	// ErrConsoleExceptions happens when there are exceptions in the Chromium
 	// console. It also happens only if the [Options.FailOnConsoleExceptions]
 	// is set to true.
@@ -75,6 +79,11 @@ type Options struct {
 	// rendered until this event is fired.
 	// Optional.
 	SkipNetworkIdleEvent bool
+
+	// FailOnHttpStatusCodes sets if the conversion should fail if the status
+	// code from the main page matches with one of its entries.
+	// Optional.
+	FailOnHttpStatusCodes []int64
 
 	// FailOnConsoleExceptions sets if the conversion should fail if there are
 	// exceptions in the Chromium console.
@@ -179,6 +188,7 @@ type Options struct {
 func DefaultOptions() Options {
 	return Options{
 		SkipNetworkIdleEvent:    false,
+		FailOnHttpStatusCodes:   []int64{499, 599},
 		FailOnConsoleExceptions: false,
 		WaitDelay:               0,
 		WaitWindowStatus:        "",
@@ -436,7 +446,7 @@ func (mod *Chromium) Routes() ([]api.Route, error) {
 
 // Pdf converts a URL to PDF.
 func (mod *Chromium) Pdf(ctx context.Context, logger *zap.Logger, url, outputPath string, options Options) error {
-	// FIXME: no error wrapping because it leaks on console exceptions output.
+	// Note: no error wrapping because it leaks on console exceptions output.
 	return mod.supervisor.Run(ctx, logger, func() error {
 		return mod.browser.pdf(ctx, logger, url, outputPath, options)
 	})

--- a/pkg/modules/chromium/routes_test.go
+++ b/pkg/modules/chromium/routes_test.go
@@ -29,6 +29,40 @@ func TestFormDataChromiumPdfOptions(t *testing.T) {
 			expectedOptions: DefaultOptions(),
 		},
 		{
+			scenario: "invalid failOnHttpStatusCodes form field",
+			ctx: func() *api.ContextMock {
+				ctx := &api.ContextMock{Context: new(api.Context)}
+				ctx.SetValues(map[string][]string{
+					"failOnHttpStatusCodes": {
+						"foo",
+					},
+				})
+				return ctx
+			}(),
+			expectedOptions: func() Options {
+				options := DefaultOptions()
+				options.FailOnHttpStatusCodes = nil
+				return options
+			}(),
+		},
+		{
+			scenario: "valid failOnHttpStatusCodes form field",
+			ctx: func() *api.ContextMock {
+				ctx := &api.ContextMock{Context: new(api.Context)}
+				ctx.SetValues(map[string][]string{
+					"failOnHttpStatusCodes": {
+						`[399,499,599]`,
+					},
+				})
+				return ctx
+			}(),
+			expectedOptions: func() Options {
+				options := DefaultOptions()
+				options.FailOnHttpStatusCodes = []int64{399, 499, 599}
+				return options
+			}(),
+		},
+		{
 			scenario: "invalid extraHttpHeaders form field",
 			ctx: func() *api.ContextMock {
 				ctx := &api.ContextMock{Context: new(api.Context)}
@@ -637,6 +671,18 @@ func TestConvertUrl(t *testing.T) {
 			expectError:            true,
 			expectHttpError:        true,
 			expectHttpStatus:       http.StatusBadRequest,
+			expectOutputPathsCount: 0,
+		},
+		{
+			scenario: "ErrInvalidHttpStatusCode",
+			ctx:      &api.ContextMock{Context: new(api.Context)},
+			api: &ApiMock{func(ctx context.Context, logger *zap.Logger, url, outputPath string, options Options) error {
+				return ErrInvalidHttpStatusCode
+			}},
+			options:                DefaultOptions(),
+			expectError:            true,
+			expectHttpError:        true,
+			expectHttpStatus:       http.StatusConflict,
 			expectOutputPathsCount: 0,
 		},
 		{


### PR DESCRIPTION
Closes #613.

### New Feature

Now returns a `409 Conflict` if the HTTP status code from the main page is not acceptable.

The list of invalid status codes is configurable with the new form field `failOnHttpStatusCodes` that takes a JSON string representing an array of int. For instance:

```
curl --request POST \
  --url http://localhost:3000/forms/chromium/convert/url \
  --form url="https://httpstat.us/400" \
  --form 'failOnHttpStatusCodes="[499,599]"' 
```

* A `x99` represents the range between `x00` and `x99` (e.g., `499` means every HTTP status codes between `400` and `499`).
* Default value of `failOnHttpStatusCodes` is `"[499,599]"`.