### PR TITLE
feat(chromium): flags for clearing cache/cookies between each conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@ CHROMIUM_HOST_RESOLVER_RULES=
 CHROMIUM_PROXY_SERVER=
 CHROMIUM_ALLOW_LIST=
 CHROMIUM_DENY_LIST="^file:///[^tmp].*"
+CHROMIUM_CLEAR_CACHE=false
+CHROMIUM_CLEAR_COOKIES=false
 CHROMIUM_DISABLE_JAVASCRIPT=false
 CHROMIUM_DISABLE_ROUTES=false
 LIBREOFFICE_RESTART_AFTER=10
@@ -97,6 +99,8 @@ run: ## Start a Gotenberg container
 	--chromium-proxy-server=$(CHROMIUM_PROXY_SERVER) \
 	--chromium-allow-list=$(CHROMIUM_ALLOW_LIST) \
 	--chromium-deny-list=$(CHROMIUM_DENY_LIST) \
+	--chromium-clear-cache=$(CHROMIUM_CLEAR_CACHE) \
+	--chromium-clear-cookies=$(CHROMIUM_CLEAR_COOKIES) \
 	--chromium-disable-javascript=$(CHROMIUM_DISABLE_JAVASCRIPT) \
 	--chromium-disable-routes=$(CHROMIUM_DISABLE_ROUTES) \
 	--libreoffice-restart-after=$(LIBREOFFICE_RESTART_AFTER) \

--- a/pkg/modules/chromium/browser.go
+++ b/pkg/modules/chromium/browser.go
@@ -40,6 +40,8 @@ type browserArguments struct {
 	// Tasks specific.
 	allowList         *regexp.Regexp
 	denyList          *regexp.Regexp
+	clearCache        bool
+	clearCookies      bool
 	disableJavaScript bool
 }
 
@@ -267,6 +269,8 @@ func (b *chromiumBrowser) pdf(ctx context.Context, logger *zap.Logger, url, outp
 		network.Enable(),
 		fetch.Enable(),
 		runtime.Enable(),
+		clearCacheActionFunc(logger, b.arguments.clearCache),
+		clearCookiesActionFunc(logger, b.arguments.clearCookies),
 		disableJavaScriptActionFunc(logger, b.arguments.disableJavaScript),
 		extraHttpHeadersActionFunc(logger, options.ExtraHttpHeaders),
 		navigateActionFunc(logger, url, options.SkipNetworkIdleEvent),

--- a/pkg/modules/chromium/browser_test.go
+++ b/pkg/modules/chromium/browser_test.go
@@ -482,6 +482,72 @@ func TestChromiumBrowser_pdf(t *testing.T) {
 			expectedError: ErrConsoleExceptions,
 		},
 		{
+			scenario: "clear cache",
+			browser: newChromiumBrowser(
+				browserArguments{
+					binPath:          os.Getenv("CHROMIUM_BIN_PATH"),
+					wsUrlReadTimeout: 5 * time.Second,
+					allowList:        regexp.MustCompile(""),
+					denyList:         regexp.MustCompile(""),
+					clearCache:       true,
+				},
+			),
+			fs: func() *gotenberg.FileSystem {
+				fs := gotenberg.NewFileSystem()
+
+				err := os.MkdirAll(fs.WorkingDirPath(), 0o755)
+				if err != nil {
+					t.Fatalf(fmt.Sprintf("expected no error but got: %v", err))
+				}
+
+				err = os.WriteFile(fmt.Sprintf("%s/index.html", fs.WorkingDirPath()), []byte("<h1>Clear cache</h1>"), 0o755)
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+
+				return fs
+			}(),
+			noDeadline:  false,
+			start:       true,
+			expectError: false,
+			expectedLogEntries: []string{
+				"clear cache",
+			},
+		},
+		{
+			scenario: "clear cookies",
+			browser: newChromiumBrowser(
+				browserArguments{
+					binPath:          os.Getenv("CHROMIUM_BIN_PATH"),
+					wsUrlReadTimeout: 5 * time.Second,
+					allowList:        regexp.MustCompile(""),
+					denyList:         regexp.MustCompile(""),
+					clearCookies:     true,
+				},
+			),
+			fs: func() *gotenberg.FileSystem {
+				fs := gotenberg.NewFileSystem()
+
+				err := os.MkdirAll(fs.WorkingDirPath(), 0o755)
+				if err != nil {
+					t.Fatalf(fmt.Sprintf("expected no error but got: %v", err))
+				}
+
+				err = os.WriteFile(fmt.Sprintf("%s/index.html", fs.WorkingDirPath()), []byte("<h1>Clear cookies</h1>"), 0o755)
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+
+				return fs
+			}(),
+			noDeadline:  false,
+			start:       true,
+			expectError: false,
+			expectedLogEntries: []string{
+				"clear cookies",
+			},
+		},
+		{
 			scenario: "disable JavaScript",
 			browser: newChromiumBrowser(
 				browserArguments{
@@ -1024,6 +1090,8 @@ func TestChromiumBrowser_pdf(t *testing.T) {
 			start:       true,
 			expectError: false,
 			expectedLogEntries: []string{
+				"cache not cleared",
+				"cookies not cleared",
 				"JavaScript not disabled",
 				"no extra HTTP headers",
 				"navigate to",

--- a/pkg/modules/chromium/chromium.go
+++ b/pkg/modules/chromium/chromium.go
@@ -246,6 +246,8 @@ func (mod *Chromium) Descriptor() gotenberg.ModuleDescriptor {
 			fs.String("chromium-proxy-server", "", "Set the outbound proxy server; this switch only affects HTTP and HTTPS requests")
 			fs.String("chromium-allow-list", "", "Set the allowed URLs for Chromium using a regular expression")
 			fs.String("chromium-deny-list", "^file:///[^tmp].*", "Set the denied URLs for Chromium using a regular expression")
+			fs.Bool("chromium-clear-cache", false, "Clear Chromium cache between each conversion")
+			fs.Bool("chromium-clear-cookies", false, "Clear Chromium cookies between each conversion")
 			fs.Bool("chromium-disable-javascript", false, "Disable JavaScript")
 			fs.Bool("chromium-disable-routes", false, "Disable the routes")
 
@@ -279,6 +281,8 @@ func (mod *Chromium) Provision(ctx *gotenberg.Context) error {
 
 		allowList:         flags.MustRegexp("chromium-allow-list"),
 		denyList:          flags.MustRegexp("chromium-deny-list"),
+		clearCache:        flags.MustBool("chromium-clear-cache"),
+		clearCookies:      flags.MustBool("chromium-clear-cookies"),
 		disableJavaScript: flags.MustBool("chromium-disable-javascript"),
 	}
 

--- a/pkg/modules/chromium/tasks.go
+++ b/pkg/modules/chromium/tasks.go
@@ -92,12 +92,49 @@ func printToPdfActionFunc(logger *zap.Logger, outputPath string, options Options
 	}
 }
 
+func clearCacheActionFunc(logger *zap.Logger, clear bool) chromedp.ActionFunc {
+	return func(ctx context.Context) error {
+		// See https://github.com/gotenberg/gotenberg/issues/753.
+		if !clear {
+			logger.Debug("cache not cleared")
+			return nil
+		}
+
+		logger.Debug("clear cache")
+
+		err := network.ClearBrowserCache().Do(ctx)
+		if err == nil {
+			return nil
+		}
+
+		return fmt.Errorf("clear cache: %w", err)
+	}
+}
+
+func clearCookiesActionFunc(logger *zap.Logger, clear bool) chromedp.ActionFunc {
+	return func(ctx context.Context) error {
+		// See https://github.com/gotenberg/gotenberg/issues/753.
+		if !clear {
+			logger.Debug("cookies not cleared")
+			return nil
+		}
+
+		logger.Debug("clear cookies")
+
+		err := network.ClearBrowserCookies().Do(ctx)
+		if err == nil {
+			return nil
+		}
+
+		return fmt.Errorf("clear cookies: %w", err)
+	}
+}
+
 func disableJavaScriptActionFunc(logger *zap.Logger, disable bool) chromedp.ActionFunc {
 	return func(ctx context.Context) error {
 		// See https://github.com/gotenberg/gotenberg/issues/175.
 		if !disable {
 			logger.Debug("JavaScript not disabled")
-
 			return nil
 		}
 
@@ -116,7 +153,6 @@ func extraHttpHeadersActionFunc(logger *zap.Logger, extraHttpHeaders map[string]
 	return func(ctx context.Context) error {
 		if len(extraHttpHeaders) == 0 {
 			logger.Debug("no extra HTTP headers")
-
 			return nil
 		}
 


### PR DESCRIPTION
### New Feature

New flags `--chromium-clear-cache` and `--chromium-clear-cookies` (bool, default to `false`).
Respectively clear the cache and cookies between each conversion if set to `true`.