### PR TITLE
feat(libreoffice): preserve filenames for zipped files instead of using randomly generated UUID filenames

### DIFF
--- a/pkg/modules/api/context.go
+++ b/pkg/modules/api/context.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -13,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/mholt/archiver/v3"
 	"go.uber.org/zap"
@@ -191,10 +191,18 @@ func (ctx *Context) FormData() *FormData {
 	}
 }
 
-// GeneratePath generates a path within the context's working directory. It
-// does not create a file.
-func (ctx *Context) GeneratePath(extension string) string {
-	return fmt.Sprintf("%s/%s%s", ctx.dirPath, uuid.New(), extension)
+// GeneratePath generates a path within the context's working directory. It does not create a file.
+// It either generates a new UUID-based filename or uses the provided filename.
+func (ctx *Context) GeneratePath(extension string, optionalFilename ...string) string {
+	var filename string
+	if len(optionalFilename) > 0 {
+		// Use the provided filename
+		filename = optionalFilename[0]
+	} else {
+		// Generate a new UUID-based filename
+		filename = uuid.New().String()
+	}
+	return fmt.Sprintf("%s/%s%s", ctx.dirPath, filename, extension)
 }
 
 // AddOutputPaths adds the given paths. Those paths will be used later to build

--- a/pkg/modules/api/context.go
+++ b/pkg/modules/api/context.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -14,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/mholt/archiver/v3"
 	"go.uber.org/zap"


### PR DESCRIPTION
Addresses issue [771](https://github.com/gotenberg/gotenberg/issues/771)

**Why this feature?**

The filenames generated by the `libreoffice/convert` route returns randomly generated UUID filenames that are then archived in a zip file. For example, `document.docx` would then become `9790de13-5754-49db-aaee-51c8d599c0c0.pdf` after conversion.

**Solution**

Preserve the original filenames for conversion. The example file `document.docx` would then become `document.pdf`. This solution also address an edge case where there may be multiple filenames with the same filename but different extensions. `document.doc` and `document.docx` would then become `document.doc.pdf` and `document.docx.pdf`.