### PR TITLE
TaggingPDF results in large filesize but accessible PDFs, Lets make it optional

### DIFF
--- a/pkg/modules/chromium/chromium.go
+++ b/pkg/modules/chromium/chromium.go
@@ -205,6 +205,12 @@ type PdfOptions struct {
 	// If false, the content will be scaled to fit the paper size.
 	// Optional.
 	PreferCssPageSize bool
+
+	// GenerateTaggedPDF produces a type of PDF that includes an underlying tag tree, similar to HTML, that defines the structure of the document.
+	// A key part of making PDFs accessible is ensuring the document is “tagged.”
+	// If false, the underlying tag tree will be omitted
+	// Optional.
+	GenerateTaggedPDF bool
 }
 
 // DefaultPdfOptions returns the default values for PdfOptions.
@@ -225,6 +231,7 @@ func DefaultPdfOptions() PdfOptions {
 		HeaderTemplate:    "<html><head></head><body></body></html>",
 		FooterTemplate:    "<html><head></head><body></body></html>",
 		PreferCssPageSize: false,
+		GenerateTaggedPDF: true,
 	}
 }
 

--- a/pkg/modules/chromium/tasks.go
+++ b/pkg/modules/chromium/tasks.go
@@ -47,7 +47,7 @@ func printToPdfActionFunc(logger *zap.Logger, outputPath string, options PdfOpti
 			WithMarginRight(options.MarginRight).
 			WithPageRanges(pageRanges).
 			WithPreferCSSPageSize(options.PreferCssPageSize).
-			WithGenerateTaggedPDF(true)
+			WithGenerateTaggedPDF(options.GenerateTaggedPDF)
 
 		hasCustomHeaderFooter := options.HeaderTemplate != DefaultPdfOptions().HeaderTemplate ||
 			options.FooterTemplate != DefaultPdfOptions().FooterTemplate


### PR DESCRIPTION
numerous issues 
- https://github.com/microsoft/playwright/issues/13917
- https://github.com/puppeteer/puppeteer/issues/8100
- 