### PR TITLE
TaggingPDF results in large filesize but accessible PDFs, Lets make it optional

### DIFF
--- a/pkg/modules/chromium/chromium.go
+++ b/pkg/modules/chromium/chromium.go
@@ -205,6 +205,12 @@ type PdfOptions struct {
 	// If false, the content will be scaled to fit the paper size.
 	// Optional.
 	PreferCssPageSize bool
+
+	// GenerateTaggedPDF produces a type of PDF that includes an underlying tag tree, similar to HTML, that defines the structure of the document.
+	// A key part of making PDFs accessible is ensuring the document is “tagged.”
+	// If false, the underlying tag tree will be omitted
+	// Optional.
+	GenerateTaggedPDF bool
 }
 
 // DefaultPdfOptions returns the default values for PdfOptions.
@@ -225,6 +231,7 @@ func DefaultPdfOptions() PdfOptions {
 		HeaderTemplate:    "<html><head></head><body></body></html>",
 		FooterTemplate:    "<html><head></head><body></body></html>",
 		PreferCssPageSize: false,
+		GenerateTaggedPDF: true,
 	}
 }
 

--- a/pkg/modules/chromium/routes.go
+++ b/pkg/modules/chromium/routes.go
@@ -115,6 +115,7 @@ func FormDataChromiumPdfOptions(ctx *api.Context) (*api.FormData, PdfOptions) {
 		pageRanges                                       string
 		headerTemplate, footerTemplate                   string
 		preferCssPageSize                                bool
+		generateTaggedPdf                                bool
 	)
 
 	form.
@@ -132,6 +133,7 @@ func FormDataChromiumPdfOptions(ctx *api.Context) (*api.FormData, PdfOptions) {
 		Content("header.html", &headerTemplate, defaultPdfOptions.HeaderTemplate).
 		Content("footer.html", &footerTemplate, defaultPdfOptions.FooterTemplate).
 		Bool("preferCssPageSize", &preferCssPageSize, defaultPdfOptions.PreferCssPageSize)
+		Bool("generateTaggedPdf", &generateTaggedPdf, defaultPdfOptions.GenerateTaggedPDF)
 
 	pdfOptions := PdfOptions{
 		Options:           options,
@@ -149,6 +151,7 @@ func FormDataChromiumPdfOptions(ctx *api.Context) (*api.FormData, PdfOptions) {
 		HeaderTemplate:    headerTemplate,
 		FooterTemplate:    footerTemplate,
 		PreferCssPageSize: preferCssPageSize,
+		GenerateTaggedPDF: generateTaggedPdf,
 	}
 
 	return form, pdfOptions

--- a/pkg/modules/chromium/tasks.go
+++ b/pkg/modules/chromium/tasks.go
@@ -47,7 +47,7 @@ func printToPdfActionFunc(logger *zap.Logger, outputPath string, options PdfOpti
 			WithMarginRight(options.MarginRight).
 			WithPageRanges(pageRanges).
 			WithPreferCSSPageSize(options.PreferCssPageSize).
-			WithGenerateTaggedPDF(true)
+			WithGenerateTaggedPDF(options.GenerateTaggedPDF)
 
 		hasCustomHeaderFooter := options.HeaderTemplate != DefaultPdfOptions().HeaderTemplate ||
 			options.FooterTemplate != DefaultPdfOptions().FooterTemplate


### PR DESCRIPTION
numerous issues 
- https://github.com/microsoft/playwright/issues/13917
- https://github.com/puppeteer/puppeteer/issues/8100