### PR TITLE
feat(chromium): add multi element screenshots

### DIFF
--- a/pkg/modules/chromium/browser.go
+++ b/pkg/modules/chromium/browser.go
@@ -23,7 +23,7 @@ import (
 type browser interface {
 	gotenberg.Process
 	pdf(ctx context.Context, logger *zap.Logger, url, outputPath string, options PdfOptions) error
-	screenshot(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error
+	screenshot(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error
 }
 
 type browserArguments struct {
@@ -236,7 +236,7 @@ func (b *chromiumBrowser) pdf(ctx context.Context, logger *zap.Logger, url, outp
 	})
 }
 
-func (b *chromiumBrowser) screenshot(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+func (b *chromiumBrowser) screenshot(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 	// Note: no error wrapping because it leaks on errors we want to display to
 	// the end user.
 	return b.do(ctx, logger, url, options.Options, chromedp.Tasks{
@@ -254,7 +254,7 @@ func (b *chromiumBrowser) screenshot(ctx context.Context, logger *zap.Logger, ur
 		waitDelayBeforePrintActionFunc(logger, b.arguments.disableJavaScript, options.WaitDelay),
 		waitForExpressionBeforePrintActionFunc(logger, b.arguments.disableJavaScript, options.WaitForExpression),
 		// Screenshot specific.
-		captureScreenshotActionFunc(logger, outputPath, options),
+		captureScreenshotActionFunc(logger, outputPaths, options),
 	})
 }
 

--- a/pkg/modules/chromium/browser_test.go
+++ b/pkg/modules/chromium/browser_test.go
@@ -2014,7 +2014,7 @@ func TestChromiumBrowser_screenshot(t *testing.T) {
 				ctx,
 				logger,
 				fmt.Sprintf("file://%s/index.html", tc.fs.WorkingDirPath()),
-				fmt.Sprintf("%s/%s.pdf", tc.fs.WorkingDirPath(), uuid.NewString()),
+				[]string{fmt.Sprintf("%s/%s.pdf", tc.fs.WorkingDirPath(), uuid.NewString())},
 				tc.options,
 			)
 

--- a/pkg/modules/chromium/chromium.go
+++ b/pkg/modules/chromium/chromium.go
@@ -247,10 +247,10 @@ type ScreenshotOptions struct {
 	// Optional.
 	OptimizeForSpeed bool
 
-	// Selectors can be one or more CSS selectors to capture
+	// Selectors can be one or more DOM selectors to capture.
 	Selectors []string
 
-	// Scales screenshots captured with a CSS selector.
+	// Scales screenshots captured with a selector.
 	Scale float64
 }
 

--- a/pkg/modules/chromium/chromium.go
+++ b/pkg/modules/chromium/chromium.go
@@ -247,7 +247,7 @@ type ScreenshotOptions struct {
 	// Optional.
 	OptimizeForSpeed bool
 
-	// Selectors can be one or more DOM selectors to capture.
+	// Selectors can be one or more DOM selectors to capture e.g. document.querySelector(...).
 	Selectors []string
 
 	// Scales screenshots captured with a selector.

--- a/pkg/modules/chromium/chromium.go
+++ b/pkg/modules/chromium/chromium.go
@@ -246,6 +246,12 @@ type ScreenshotOptions struct {
 	// not for resulting size.
 	// Optional.
 	OptimizeForSpeed bool
+
+	// Selectors can be one or more CSS selectors to capture
+	Selectors []string
+
+	// Scales screenshots captured with a CSS selector.
+	Scale float64
 }
 
 // DefaultScreenshotOptions returns the default values for ScreenshotOptions.
@@ -255,13 +261,14 @@ func DefaultScreenshotOptions() ScreenshotOptions {
 		Format:           "png",
 		Quality:          100,
 		OptimizeForSpeed: false,
+		Scale:            1,
 	}
 }
 
 // Api helps to interact with Chromium for converting HTML documents to PDF.
 type Api interface {
-	Pdf(ctx context.Context, logger *zap.Logger, url, outputPath string, options PdfOptions) error
-	Screenshot(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error
+	Pdf(ctx context.Context, logger *zap.Logger, url string, outputPath string, options PdfOptions) error
+	Screenshot(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error
 }
 
 // Provider is a module interface which exposes a method for creating an [Api]
@@ -508,11 +515,11 @@ func (mod *Chromium) Pdf(ctx context.Context, logger *zap.Logger, url, outputPat
 	})
 }
 
-func (mod *Chromium) Screenshot(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+func (mod *Chromium) Screenshot(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 	// Note: no error wrapping because it leaks on errors we want to display to
 	// the end user.
 	return mod.supervisor.Run(ctx, logger, func() error {
-		return mod.browser.screenshot(ctx, logger, url, outputPath, options)
+		return mod.browser.screenshot(ctx, logger, url, outputPaths, options)
 	})
 }
 

--- a/pkg/modules/chromium/chromium_test.go
+++ b/pkg/modules/chromium/chromium_test.go
@@ -537,14 +537,14 @@ func TestChromium_Screenshot(t *testing.T) {
 	}{
 		{
 			scenario: "Screenshot task success",
-			browser: &browserMock{screenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+			browser: &browserMock{screenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 				return nil
 			}},
 			expectError: false,
 		},
 		{
 			scenario: "Screenshot task error",
-			browser: &browserMock{screenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+			browser: &browserMock{screenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 				return errors.New("screenshot task error")
 			}},
 			expectError: true,
@@ -557,7 +557,7 @@ func TestChromium_Screenshot(t *testing.T) {
 			}}
 			mod.browser = tc.browser
 
-			err := mod.Screenshot(context.Background(), zap.NewNop(), "", "", ScreenshotOptions{})
+			err := mod.Screenshot(context.Background(), zap.NewNop(), "", []string{""}, ScreenshotOptions{})
 
 			if !tc.expectError && err != nil {
 				t.Fatalf("expected no error but got: %v", err)

--- a/pkg/modules/chromium/mocks.go
+++ b/pkg/modules/chromium/mocks.go
@@ -11,30 +11,30 @@ import (
 // ApiMock is a mock for the [Api] interface.
 type ApiMock struct {
 	PdfMock        func(ctx context.Context, logger *zap.Logger, url, outputPath string, options PdfOptions) error
-	ScreenshotMock func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error
+	ScreenshotMock func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error
 }
 
 func (api *ApiMock) Pdf(ctx context.Context, logger *zap.Logger, url, outputPath string, options PdfOptions) error {
 	return api.PdfMock(ctx, logger, url, outputPath, options)
 }
 
-func (api *ApiMock) Screenshot(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
-	return api.ScreenshotMock(ctx, logger, url, outputPath, options)
+func (api *ApiMock) Screenshot(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
+	return api.ScreenshotMock(ctx, logger, url, outputPaths, options)
 }
 
 // browserMock is a mock for the [browser] interface.
 type browserMock struct {
 	gotenberg.ProcessMock
 	pdfMock        func(ctx context.Context, logger *zap.Logger, url, outputPath string, options PdfOptions) error
-	screenshotMock func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error
+	screenshotMock func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error
 }
 
 func (b *browserMock) pdf(ctx context.Context, logger *zap.Logger, url, outputPath string, options PdfOptions) error {
 	return b.pdfMock(ctx, logger, url, outputPath, options)
 }
 
-func (b *browserMock) screenshot(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
-	return b.screenshotMock(ctx, logger, url, outputPath, options)
+func (b *browserMock) screenshot(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
+	return b.screenshotMock(ctx, logger, url, outputPaths, options)
 }
 
 // Interface guards.

--- a/pkg/modules/chromium/mocks_test.go
+++ b/pkg/modules/chromium/mocks_test.go
@@ -12,7 +12,7 @@ func TestApiMock(t *testing.T) {
 		PdfMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options PdfOptions) error {
 			return nil
 		},
-		ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+		ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 			return nil
 		},
 	}
@@ -22,7 +22,7 @@ func TestApiMock(t *testing.T) {
 		t.Errorf("expected no error from ApiMock.Pdf, but got: %v", err)
 	}
 
-	err = mock.Screenshot(context.Background(), zap.NewNop(), "", "", ScreenshotOptions{})
+	err = mock.Screenshot(context.Background(), zap.NewNop(), "", []string{""}, ScreenshotOptions{})
 	if err != nil {
 		t.Errorf("expected no error from ApiMock.Screenshot, but got: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestBrowserMock(t *testing.T) {
 		pdfMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options PdfOptions) error {
 			return nil
 		},
-		screenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+		screenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 			return nil
 		},
 	}
@@ -43,7 +43,7 @@ func TestBrowserMock(t *testing.T) {
 		t.Errorf("expected no error from browserMock.pdf, but got: %v", err)
 	}
 
-	err = mock.screenshot(context.Background(), zap.NewNop(), "", "", ScreenshotOptions{})
+	err = mock.screenshot(context.Background(), zap.NewNop(), "", []string{""}, ScreenshotOptions{})
 	if err != nil {
 		t.Errorf("expected no error from browserMock.screenshot, but got: %v", err)
 	}

--- a/pkg/modules/chromium/routes_test.go
+++ b/pkg/modules/chromium/routes_test.go
@@ -555,7 +555,7 @@ func TestScreenshotUrlRoute(t *testing.T) {
 				})
 				return ctx
 			}(),
-			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 				return errors.New("foo")
 			}},
 			expectError:            true,
@@ -573,7 +573,7 @@ func TestScreenshotUrlRoute(t *testing.T) {
 				})
 				return ctx
 			}(),
-			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 				return nil
 			}},
 			expectError:            false,
@@ -739,7 +739,7 @@ func TestScreenshotHtmlRoute(t *testing.T) {
 				})
 				return ctx
 			}(),
-			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 				return errors.New("foo")
 			}},
 			expectError:            true,
@@ -755,7 +755,7 @@ func TestScreenshotHtmlRoute(t *testing.T) {
 				})
 				return ctx
 			}(),
-			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 				return nil
 			}},
 			expectError:            false,
@@ -1125,7 +1125,7 @@ func TestScreenshotMarkdownRoute(t *testing.T) {
 
 				return ctx
 			}(),
-			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 				return errors.New("foo")
 			}},
 			expectError:            true,
@@ -1160,7 +1160,7 @@ func TestScreenshotMarkdownRoute(t *testing.T) {
 
 				return ctx
 			}(),
-			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 				return nil
 			}},
 			expectError:            false,
@@ -1437,7 +1437,7 @@ func TestScreenshotUrl(t *testing.T) {
 		{
 			scenario: "ErrInvalidEvaluationExpression (without waitForExpression form field)",
 			ctx:      &api.ContextMock{Context: new(api.Context)},
-			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 				return ErrInvalidEvaluationExpression
 			}},
 			options:                DefaultScreenshotOptions(),
@@ -1448,7 +1448,7 @@ func TestScreenshotUrl(t *testing.T) {
 		{
 			scenario: "ErrInvalidEvaluationExpression (with waitForExpression form field)",
 			ctx:      &api.ContextMock{Context: new(api.Context)},
-			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 				return ErrInvalidEvaluationExpression
 			}},
 			options: func() ScreenshotOptions {
@@ -1465,7 +1465,7 @@ func TestScreenshotUrl(t *testing.T) {
 		{
 			scenario: "ErrInvalidHttpStatusCode",
 			ctx:      &api.ContextMock{Context: new(api.Context)},
-			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 				return ErrInvalidHttpStatusCode
 			}},
 			options:                DefaultScreenshotOptions(),
@@ -1477,7 +1477,7 @@ func TestScreenshotUrl(t *testing.T) {
 		{
 			scenario: "ErrConsoleExceptions",
 			ctx:      &api.ContextMock{Context: new(api.Context)},
-			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 				return ErrConsoleExceptions
 			}},
 			options:                DefaultScreenshotOptions(),
@@ -1489,7 +1489,7 @@ func TestScreenshotUrl(t *testing.T) {
 		{
 			scenario: "error from Chromium",
 			ctx:      &api.ContextMock{Context: new(api.Context)},
-			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 				return errors.New("foo")
 			}},
 			options:                DefaultScreenshotOptions(),
@@ -1504,7 +1504,7 @@ func TestScreenshotUrl(t *testing.T) {
 				ctx.SetCancelled(true)
 				return ctx
 			}(),
-			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 				return nil
 			}},
 			options:                DefaultScreenshotOptions(),
@@ -1515,7 +1515,7 @@ func TestScreenshotUrl(t *testing.T) {
 		{
 			scenario: "success",
 			ctx:      &api.ContextMock{Context: new(api.Context)},
-			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url, outputPath string, options ScreenshotOptions) error {
+			api: &ApiMock{ScreenshotMock: func(ctx context.Context, logger *zap.Logger, url string, outputPaths []string, options ScreenshotOptions) error {
 				return nil
 			}},
 			options:                DefaultScreenshotOptions(),

--- a/pkg/modules/chromium/tasks.go
+++ b/pkg/modules/chromium/tasks.go
@@ -151,7 +151,7 @@ func captureScreenshotActionFunc(logger *zap.Logger, outputPaths []string, optio
 					}
 					nodes = append(nodes, selectedNodes[0])
 					return nil
-				}))
+				}, chromedp.ByQuery))
 
 				if err != nil {
 					return err

--- a/pkg/modules/chromium/tasks.go
+++ b/pkg/modules/chromium/tasks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/chromedp/cdproto/emulation"
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/cdproto/page"
+	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
 	"go.uber.org/zap"
 )
@@ -110,45 +111,104 @@ func printToPdfActionFunc(logger *zap.Logger, outputPath string, options PdfOpti
 	}
 }
 
-func captureScreenshotActionFunc(logger *zap.Logger, outputPath string, options ScreenshotOptions) chromedp.ActionFunc {
+func captureScreenshotActionFunc(logger *zap.Logger, outputPaths []string, options ScreenshotOptions) chromedp.ActionFunc {
+
 	return func(ctx context.Context) error {
-		captureScreenshot := page.CaptureScreenshot().
-			WithCaptureBeyondViewport(true).
-			WithFromSurface(true).
-			WithOptimizeForSpeed(options.OptimizeForSpeed).
-			WithFormat(page.CaptureScreenshotFormat(options.Format))
+		var buf []byte
+		var err error
+		if options.Selectors == nil && len(outputPaths) == 1 {
+			captureScreenshot := page.CaptureScreenshot().
+				WithCaptureBeyondViewport(true).
+				WithFromSurface(true).
+				WithOptimizeForSpeed(options.OptimizeForSpeed).
+				WithFormat(page.CaptureScreenshotFormat(options.Format))
 
-		if options.Format == "jpeg" {
-			captureScreenshot = captureScreenshot.
-				WithQuality(int64(options.Quality))
-		}
-
-		logger.Debug(fmt.Sprintf("capture screenshot with: %+v", captureScreenshot))
-
-		buffer, err := captureScreenshot.Do(ctx)
-		if err != nil {
-			return fmt.Errorf("capture screenshot: %w", err)
-		}
-
-		file, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY, 0o600)
-		if err != nil {
-			return fmt.Errorf("open output path: %w", err)
-		}
-
-		defer func() {
-			err = file.Close()
-			if err != nil {
-				logger.Error(fmt.Sprintf("close output path: %s", err))
+			if options.Format == "jpeg" {
+				captureScreenshot = captureScreenshot.
+					WithQuality(int64(options.Quality))
 			}
-		}()
 
-		_, err = file.Write(buffer)
-		if err != nil {
-			return fmt.Errorf("write result to output path: %w", err)
+			logger.Debug(fmt.Sprintf("capture screenshot with: %+v", captureScreenshot))
+
+			buf, err = captureScreenshot.Do(ctx)
+			if err != nil {
+				return fmt.Errorf("capture screenshot: %w", err)
+			}
+
+			failure, err := writeBuffer(outputPaths[0], logger, buf)
+			if failure {
+				return err
+			}
+		} else if len(outputPaths) == len(options.Selectors) {
+			for i, outputPath := range outputPaths {
+				logger.Debug(fmt.Sprintf("capture screenshot to '%s'", outputPath))
+				sel := options.Selectors[i]
+
+				nodes := make([]*cdp.Node, 0)
+				err = chromedp.Run(ctx, chromedp.QueryAfter(sel, func(_ctx context.Context, _execCtx runtime.ExecutionContextID, selectedNodes ...*cdp.Node) error {
+					if len(selectedNodes) < 1 {
+						return fmt.Errorf("selector %q did not return any nodes", sel)
+					}
+					nodes = append(nodes, selectedNodes[0])
+					return nil
+				}))
+
+				if err != nil {
+					return err
+				}
+
+				err = chromedp.Run(ctx,
+					// scrolls offscreen elements into view because they often had poor/inconsistent clipping
+					chromedp.Evaluate(fmt.Sprintf("document.querySelector('%+v').scrollIntoViewIfNeeded(true)", sel), nil),
+					// request an animation frame to wait for any offscreen content to finish rendering
+					chromedp.Evaluate(`window.requestAnimationFrame(() => {window.animationComplete = true})`, nil),
+				)
+
+				if err != nil {
+					return fmt.Errorf("scroll into view: %w", err)
+				}
+
+				err = waitForExpressionBeforePrintActionFunc(logger, false, `window.animationComplete == true`)(ctx)
+				if err != nil {
+					return fmt.Errorf("wait for animation complete: %w", err)
+				}
+
+				err = chromedp.Run(ctx, chromedp.ScreenshotNodes(nodes, options.Scale, &buf),
+					chromedp.Evaluate(`window.animationComplete = false`, nil))
+
+				if err != nil {
+					return fmt.Errorf("capture screenshot: %w", err)
+				}
+
+				failure, err := writeBuffer(outputPath, logger, buf)
+				if failure {
+					return err
+				}
+			}
 		}
 
 		return nil
 	}
+}
+
+func writeBuffer(outputPath string, logger *zap.Logger, buf []byte) (bool, error) {
+	file, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return true, fmt.Errorf("open output path: %w", err)
+	}
+
+	defer func() {
+		err = file.Close()
+		if err != nil {
+			logger.Error(fmt.Sprintf("close output path: %s", err))
+		}
+	}()
+
+	_, err = file.Write(buf)
+	if err != nil {
+		return true, fmt.Errorf("write result to output path: %w", err)
+	}
+	return false, nil
 }
 
 func clearCacheActionFunc(logger *zap.Logger, clear bool) chromedp.ActionFunc {


### PR DESCRIPTION
## Motivation behind this PR
Hi, I'm looking to capture multiple screenshots using element selectors. Could that fit into Gotenberg / work on top of the existing screenshot/url route? Here's my approach.

## Summary of changes

- Adds Selector & Scale props to the Screenshot parameters
```
// Selectors can be one or more DOM selectors to capture e.g. document.querySelector(...).
Selectors []string
// Scales screenshots captured with a selector.
Scale float64
```
- Screenshot route generates outputPaths to match the number of selectors & associated wiring to change the function signature everywhere.
- Alternate flow in the screenshot task to fetch the first node matching the selector and screenshot it using `chromedp.ScreenshotNodes` 
## How to test
```cmd
λ curl -X POST -F "url=https://youtube.com" -F "selectors=[\"a[id=thumbnail][href]\"]" -o screenshot.png http://localhost:3000/forms/chromium/screenshot/url

λ curl -X POST -F "url=https://google.com" -F "selectors=[\"img\", \"form\"]" -F "scale=4" -o screenshots.zip http://localhost:3000/forms/chromium/screenshot/url
```
## Miscellaneous

Biggest issue I found was the screenshotNodes function doesn't allow for the other screenshot arguments (quality, format, optimizeForSpeed) so it's awkward for them to share the same api route. Could break it out to a new `screenshots/url` route?

Another awkward bit is the multiple file handling with `outputPaths`, perhaps the screenshot task could return back the outputs it saved? Seemed like a bigger shift so currently its just dictating 1 file per selector and returning them as numbered 0.png, 1.png, ... to fit.

First time writing Go, hope it blends!