### PR TITLE
feat(libreoffice): add exportFormFields option

### DIFF
--- a/pkg/modules/libreoffice/api/api.go
+++ b/pkg/modules/libreoffice/api/api.go
@@ -50,6 +50,11 @@ type Options struct {
 	// Optional.
 	PageRanges string
 
+	// Form fields from input is exported as form fields in the resulting PDF.
+	// Defaults to true
+	// Optional.
+	ExportFormFields bool
+
 	// PdfFormats allows to convert the resulting PDF to PDF/A-1b, PDF/A-2b,
 	// PDF/A-3b and PDF/UA.
 	// Optional.

--- a/pkg/modules/libreoffice/api/api.go
+++ b/pkg/modules/libreoffice/api/api.go
@@ -50,8 +50,7 @@ type Options struct {
 	// Optional.
 	PageRanges string
 
-	// Form fields from input is exported as form fields in the resulting PDF.
-	// Defaults to true
+	// ExportFormFields allows to... export form fields in the resulting PDF.
 	// Optional.
 	ExportFormFields bool
 

--- a/pkg/modules/libreoffice/api/libreoffice.go
+++ b/pkg/modules/libreoffice/api/libreoffice.go
@@ -273,6 +273,10 @@ func (p *libreOfficeProcess) pdf(ctx context.Context, logger *zap.Logger, inputP
 		args = append(args, "--export", fmt.Sprintf("PageRange=%s", options.PageRanges))
 	}
 
+	if !options.ExportFormFields {
+		args = append(args, "--export", "ExportFormFields=false")
+	}
+
 	switch options.PdfFormats.PdfA {
 	case "":
 	case gotenberg.PdfA1b:

--- a/pkg/modules/libreoffice/api/libreoffice_test.go
+++ b/pkg/modules/libreoffice/api/libreoffice_test.go
@@ -365,6 +365,35 @@ func TestLibreOfficeProcess_pdf(t *testing.T) {
 			expectError:  false,
 		},
 		{
+			scenario: "success (disable form fields)",
+			libreOffice: newLibreOfficeProcess(
+				libreOfficeArguments{
+					binPath:      os.Getenv("LIBREOFFICE_BIN_PATH"),
+					unoBinPath:   os.Getenv("UNOCONVERTER_BIN_PATH"),
+					startTimeout: 5 * time.Second,
+				},
+			),
+			fs: func() *gotenberg.FileSystem {
+				fs := gotenberg.NewFileSystem()
+
+				err := os.MkdirAll(fs.WorkingDirPath(), 0o755)
+				if err != nil {
+					t.Fatalf(fmt.Sprintf("expected no error but got: %v", err))
+				}
+
+				err = os.WriteFile(fmt.Sprintf("%s/document.txt", fs.WorkingDirPath()), []byte("DisableFormFields"), 0o755)
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+
+				return fs
+			}(),
+			options:      Options{ExportFormFields: false},
+			cancelledCtx: false,
+			start:        true,
+			expectError:  false,
+		},
+		{
 			scenario: "success (page ranges)",
 			libreOffice: newLibreOfficeProcess(
 				libreOfficeArguments{

--- a/pkg/modules/libreoffice/routes.go
+++ b/pkg/modules/libreoffice/routes.go
@@ -31,6 +31,7 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 				pdfua            bool
 				nativePdfFormats bool
 				merge            bool
+				exportFormFields bool
 			)
 
 			err := ctx.FormData().
@@ -41,6 +42,7 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 				Bool("pdfua", &pdfua, false).
 				Bool("nativePdfFormats", &nativePdfFormats, true).
 				Bool("merge", &merge, false).
+				Bool("exportFormFields", &exportFormFields, true).
 				Validate()
 			if err != nil {
 				return fmt.Errorf("validate form data: %w", err)
@@ -56,8 +58,9 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 			for i, inputPath := range inputPaths {
 				outputPaths[i] = ctx.GeneratePath(".pdf")
 				options := libreofficeapi.Options{
-					Landscape:  landscape,
-					PageRanges: nativePageRanges,
+					Landscape:        landscape,
+					PageRanges:       nativePageRanges,
+					ExportFormFields: exportFormFields,
 				}
 
 				if nativePdfFormats {


### PR DESCRIPTION
Feel free to just close if not interested in adding this feature.

Exposes libreoffice's ExportFormFields option, defaults to `true` as this is the current behavior.
When set to `false` the output PDF will, instead of having form fields, just have the inputted/selected content of the fields.

For context I have some docx documents with selection fields that becomes pretty ugly in the output PDFs when exported as PDF form fields.
