### PR TITLE
feat(libreoffice): add singlePageSheets option

### DIFF
--- a/pkg/modules/libreoffice/api/api.go
+++ b/pkg/modules/libreoffice/api/api.go
@@ -54,6 +54,10 @@ type Options struct {
 	// Optional.
 	ExportFormFields bool
 
+	// SinglePageSheets allows to output each sheet as a single page in the resulting PDF.
+	// Optional
+	SinglePageSheets bool
+
 	// PdfFormats allows to convert the resulting PDF to PDF/A-1b, PDF/A-2b,
 	// PDF/A-3b and PDF/UA.
 	// Optional.

--- a/pkg/modules/libreoffice/api/libreoffice.go
+++ b/pkg/modules/libreoffice/api/libreoffice.go
@@ -277,6 +277,10 @@ func (p *libreOfficeProcess) pdf(ctx context.Context, logger *zap.Logger, inputP
 		args = append(args, "--export", "ExportFormFields=false")
 	}
 
+	if options.SinglePageSheets {
+		args = append(args, "--export", "SinglePageSheets=true")
+	}
+
 	switch options.PdfFormats.PdfA {
 	case "":
 	case gotenberg.PdfA1b:

--- a/pkg/modules/libreoffice/api/libreoffice_test.go
+++ b/pkg/modules/libreoffice/api/libreoffice_test.go
@@ -394,6 +394,35 @@ func TestLibreOfficeProcess_pdf(t *testing.T) {
 			expectError:  false,
 		},
 		{
+			scenario: "success (single page sheets)",
+			libreOffice: newLibreOfficeProcess(
+				libreOfficeArguments{
+					binPath:      os.Getenv("LIBREOFFICE_BIN_PATH"),
+					unoBinPath:   os.Getenv("UNOCONVERTER_BIN_PATH"),
+					startTimeout: 5 * time.Second,
+				},
+			),
+			fs: func() *gotenberg.FileSystem {
+				fs := gotenberg.NewFileSystem()
+
+				err := os.MkdirAll(fs.WorkingDirPath(), 0o755)
+				if err != nil {
+					t.Fatalf(fmt.Sprintf("expected no error but got: %v", err))
+				}
+
+				err = os.WriteFile(fmt.Sprintf("%s/document.txt", fs.WorkingDirPath()), []byte("SinglePageSheets"), 0o755)
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+
+				return fs
+			}(),
+			options:      Options{SinglePageSheets: true},
+			cancelledCtx: false,
+			start:        true,
+			expectError:  false,
+		},
+		{
 			scenario: "success (page ranges)",
 			libreOffice: newLibreOfficeProcess(
 				libreOfficeArguments{

--- a/pkg/modules/libreoffice/routes.go
+++ b/pkg/modules/libreoffice/routes.go
@@ -29,6 +29,7 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 				landscape        bool
 				nativePageRanges string
 				exportFormFields bool
+				singlePageSheets bool
 				pdfa             string
 				pdfua            bool
 				nativePdfFormats bool
@@ -41,6 +42,7 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 				Bool("landscape", &landscape, false).
 				String("nativePageRanges", &nativePageRanges, "").
 				Bool("exportFormFields", &exportFormFields, true).
+				Bool("singlePageSheets", &singlePageSheets, false).
 				String("pdfa", &pdfa, "").
 				Bool("pdfua", &pdfua, false).
 				Bool("nativePdfFormats", &nativePdfFormats, true).
@@ -72,6 +74,7 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 					Landscape:        landscape,
 					PageRanges:       nativePageRanges,
 					ExportFormFields: exportFormFields,
+					SinglePageSheets: singlePageSheets,
 				}
 
 				if nativePdfFormats {


### PR DESCRIPTION
Exposes libreoffice's SinglePageSheets option, defaults to `false` as this is the current behavior. 

Normally libreoffice will take each sheet in a spreadsheet and fit into onto 1 or more A4 pages in the output PDF.
When `SinglePageSheets` is set to `true` libreoffice will instead render the entire spreadsheet as a single page, with the size of the page being whatever fits the content.

This is useful when the output PDF is to be used digitally and not printed to paper.