### PR TITLE
Write log time in local timezone rather than UTC

### DIFF
--- a/pkg/modules/logging/logging.go
+++ b/pkg/modules/logging/logging.go
@@ -174,7 +174,7 @@ func newLogEncoder(format string) (zapcore.Encoder, error) {
 		// If interactive terminal, make output more human-readable by default.
 		// Credits: https://github.com/caddyserver/caddy/blob/v2.1.1/logging.go#L671.
 		encCfg.EncodeTime = func(ts time.Time, encoder zapcore.PrimitiveArrayEncoder) {
-			encoder.AppendString(ts.UTC().Format("2006/01/02 15:04:05.000"))
+			encoder.AppendString(ts.Local().Format("2006/01/02 15:04:05.000"))
 		}
 
 		if format == textLoggingFormat || format == autoLoggingFormat {


### PR DESCRIPTION
Time in logs was printed in utc timezone, with this change we can set environment variable TZ=XXX and time is printed in that timezone.