### PR TITLE
add libre office image options

### DIFF
--- a/pkg/modules/libreoffice/api/api.go
+++ b/pkg/modules/libreoffice/api/api.go
@@ -58,11 +58,6 @@ type Options struct {
 	// Optional
 	SinglePageSheets bool
 
-	// PdfFormats allows to convert the resulting PDF to PDF/A-1b, PDF/A-2b,
-	// PDF/A-3b and PDF/UA.
-	// Optional.
-	PdfFormats gotenberg.PdfFormats
-
 	// LosslessImageCompression allows turning lossless compression on or off to tweak image conversion performance.
 	// Optional
 	LosslessImageCompression bool
@@ -70,6 +65,11 @@ type Options struct {
 	// ReduceImageResolution allows turning on or off image resolution reduction to tweak image conversion performance.
 	// Optional
 	ReduceImageResolution bool
+
+	// PdfFormats allows to convert the resulting PDF to PDF/A-1b, PDF/A-2b,
+	// PDF/A-3b and PDF/UA.
+	// Optional.
+	PdfFormats gotenberg.PdfFormats
 }
 
 // Uno is an abstraction on top of the Universal Network Objects API.

--- a/pkg/modules/libreoffice/api/api.go
+++ b/pkg/modules/libreoffice/api/api.go
@@ -62,6 +62,14 @@ type Options struct {
 	// PDF/A-3b and PDF/UA.
 	// Optional.
 	PdfFormats gotenberg.PdfFormats
+
+	// LosslessImageCompression allows turning lossless compression on or off to tweak image conversion performance.
+	// Optional
+	LosslessImageCompression bool
+
+	// ReduceImageResolution allows turning on or off image resolution reduction to tweak image conversion performance.
+	// Optional
+	ReduceImageResolution bool
 }
 
 // Uno is an abstraction on top of the Universal Network Objects API.

--- a/pkg/modules/libreoffice/api/libreoffice.go
+++ b/pkg/modules/libreoffice/api/libreoffice.go
@@ -281,8 +281,8 @@ func (p *libreOfficeProcess) pdf(ctx context.Context, logger *zap.Logger, inputP
 		args = append(args, "--export", "SinglePageSheets=true")
 	}
 
-	if !options.LosslessImageCompression {
-		args = append(args, "--export", "UseLosslessCompression=false")
+	if options.LosslessImageCompression {
+		args = append(args, "--export", "UseLosslessCompression=true")
 	}
 
 	if !options.ReduceImageResolution {

--- a/pkg/modules/libreoffice/api/libreoffice.go
+++ b/pkg/modules/libreoffice/api/libreoffice.go
@@ -281,6 +281,14 @@ func (p *libreOfficeProcess) pdf(ctx context.Context, logger *zap.Logger, inputP
 		args = append(args, "--export", "SinglePageSheets=true")
 	}
 
+	if !options.LosslessImageCompression {
+		args = append(args, "--export", "UseLosslessCompression=false")
+	}
+
+	if !options.ReduceImageResolution {
+		args = append(args, "--export", "ReduceImageResolution=false")
+	}
+
 	switch options.PdfFormats.PdfA {
 	case "":
 	case gotenberg.PdfA1b:

--- a/pkg/modules/libreoffice/api/libreoffice_test.go
+++ b/pkg/modules/libreoffice/api/libreoffice_test.go
@@ -475,7 +475,7 @@ func TestLibreOfficeProcess_pdf(t *testing.T) {
 
 				return fs
 			}(),
-			options:      Options{LosslessImageCompression: false},
+			options:      Options{LosslessImageCompression: true},
 			cancelledCtx: false,
 			start:        true,
 			expectError:  false,

--- a/pkg/modules/libreoffice/api/libreoffice_test.go
+++ b/pkg/modules/libreoffice/api/libreoffice_test.go
@@ -567,6 +567,64 @@ func TestLibreOfficeProcess_pdf(t *testing.T) {
 			start:        true,
 			expectError:  false,
 		},
+		{
+			scenario: "success LosslessImageCompression",
+			libreOffice: newLibreOfficeProcess(
+				libreOfficeArguments{
+					binPath:      os.Getenv("LIBREOFFICE_BIN_PATH"),
+					unoBinPath:   os.Getenv("UNOCONVERTER_BIN_PATH"),
+					startTimeout: 5 * time.Second,
+				},
+			),
+			fs: func() *gotenberg.FileSystem {
+				fs := gotenberg.NewFileSystem()
+
+				err := os.MkdirAll(fs.WorkingDirPath(), 0o755)
+				if err != nil {
+					t.Fatalf(fmt.Sprintf("expected no error but got: %v", err))
+				}
+
+				err = os.WriteFile(fmt.Sprintf("%s/document.txt", fs.WorkingDirPath()), []byte("LosslessImageCompression"), 0o755)
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+
+				return fs
+			}(),
+			options:      Options{LosslessImageCompression: false},
+			cancelledCtx: false,
+			start:        true,
+			expectError:  false,
+		},
+		{
+			scenario: "success ReduceImageResolution",
+			libreOffice: newLibreOfficeProcess(
+				libreOfficeArguments{
+					binPath:      os.Getenv("LIBREOFFICE_BIN_PATH"),
+					unoBinPath:   os.Getenv("UNOCONVERTER_BIN_PATH"),
+					startTimeout: 5 * time.Second,
+				},
+			),
+			fs: func() *gotenberg.FileSystem {
+				fs := gotenberg.NewFileSystem()
+
+				err := os.MkdirAll(fs.WorkingDirPath(), 0o755)
+				if err != nil {
+					t.Fatalf(fmt.Sprintf("expected no error but got: %v", err))
+				}
+
+				err = os.WriteFile(fmt.Sprintf("%s/document.txt", fs.WorkingDirPath()), []byte("ReduceImageResolution"), 0o755)
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+
+				return fs
+			}(),
+			options:      Options{ReduceImageResolution: false},
+			cancelledCtx: false,
+			start:        true,
+			expectError:  false,
+		},
 	} {
 		t.Run(tc.scenario, func(t *testing.T) {
 			// Force the debug level.

--- a/pkg/modules/libreoffice/api/libreoffice_test.go
+++ b/pkg/modules/libreoffice/api/libreoffice_test.go
@@ -452,6 +452,64 @@ func TestLibreOfficeProcess_pdf(t *testing.T) {
 			expectError:  false,
 		},
 		{
+			scenario: "success LosslessImageCompression",
+			libreOffice: newLibreOfficeProcess(
+				libreOfficeArguments{
+					binPath:      os.Getenv("LIBREOFFICE_BIN_PATH"),
+					unoBinPath:   os.Getenv("UNOCONVERTER_BIN_PATH"),
+					startTimeout: 5 * time.Second,
+				},
+			),
+			fs: func() *gotenberg.FileSystem {
+				fs := gotenberg.NewFileSystem()
+
+				err := os.MkdirAll(fs.WorkingDirPath(), 0o755)
+				if err != nil {
+					t.Fatalf(fmt.Sprintf("expected no error but got: %v", err))
+				}
+
+				err = os.WriteFile(fmt.Sprintf("%s/document.txt", fs.WorkingDirPath()), []byte("LosslessImageCompression"), 0o755)
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+
+				return fs
+			}(),
+			options:      Options{LosslessImageCompression: false},
+			cancelledCtx: false,
+			start:        true,
+			expectError:  false,
+		},
+		{
+			scenario: "success ReduceImageResolution",
+			libreOffice: newLibreOfficeProcess(
+				libreOfficeArguments{
+					binPath:      os.Getenv("LIBREOFFICE_BIN_PATH"),
+					unoBinPath:   os.Getenv("UNOCONVERTER_BIN_PATH"),
+					startTimeout: 5 * time.Second,
+				},
+			),
+			fs: func() *gotenberg.FileSystem {
+				fs := gotenberg.NewFileSystem()
+
+				err := os.MkdirAll(fs.WorkingDirPath(), 0o755)
+				if err != nil {
+					t.Fatalf(fmt.Sprintf("expected no error but got: %v", err))
+				}
+
+				err = os.WriteFile(fmt.Sprintf("%s/document.txt", fs.WorkingDirPath()), []byte("ReduceImageResolution"), 0o755)
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+
+				return fs
+			}(),
+			options:      Options{ReduceImageResolution: false},
+			cancelledCtx: false,
+			start:        true,
+			expectError:  false,
+		},
+		{
 			scenario: "success (PDF/A-1b)",
 			libreOffice: newLibreOfficeProcess(
 				libreOfficeArguments{
@@ -563,64 +621,6 @@ func TestLibreOfficeProcess_pdf(t *testing.T) {
 				return fs
 			}(),
 			options:      Options{PdfFormats: gotenberg.PdfFormats{PdfUa: true}},
-			cancelledCtx: false,
-			start:        true,
-			expectError:  false,
-		},
-		{
-			scenario: "success LosslessImageCompression",
-			libreOffice: newLibreOfficeProcess(
-				libreOfficeArguments{
-					binPath:      os.Getenv("LIBREOFFICE_BIN_PATH"),
-					unoBinPath:   os.Getenv("UNOCONVERTER_BIN_PATH"),
-					startTimeout: 5 * time.Second,
-				},
-			),
-			fs: func() *gotenberg.FileSystem {
-				fs := gotenberg.NewFileSystem()
-
-				err := os.MkdirAll(fs.WorkingDirPath(), 0o755)
-				if err != nil {
-					t.Fatalf(fmt.Sprintf("expected no error but got: %v", err))
-				}
-
-				err = os.WriteFile(fmt.Sprintf("%s/document.txt", fs.WorkingDirPath()), []byte("LosslessImageCompression"), 0o755)
-				if err != nil {
-					t.Fatalf("expected no error but got: %v", err)
-				}
-
-				return fs
-			}(),
-			options:      Options{LosslessImageCompression: false},
-			cancelledCtx: false,
-			start:        true,
-			expectError:  false,
-		},
-		{
-			scenario: "success ReduceImageResolution",
-			libreOffice: newLibreOfficeProcess(
-				libreOfficeArguments{
-					binPath:      os.Getenv("LIBREOFFICE_BIN_PATH"),
-					unoBinPath:   os.Getenv("UNOCONVERTER_BIN_PATH"),
-					startTimeout: 5 * time.Second,
-				},
-			),
-			fs: func() *gotenberg.FileSystem {
-				fs := gotenberg.NewFileSystem()
-
-				err := os.MkdirAll(fs.WorkingDirPath(), 0o755)
-				if err != nil {
-					t.Fatalf(fmt.Sprintf("expected no error but got: %v", err))
-				}
-
-				err = os.WriteFile(fmt.Sprintf("%s/document.txt", fs.WorkingDirPath()), []byte("ReduceImageResolution"), 0o755)
-				if err != nil {
-					t.Fatalf("expected no error but got: %v", err)
-				}
-
-				return fs
-			}(),
-			options:      Options{ReduceImageResolution: false},
 			cancelledCtx: false,
 			start:        true,
 			expectError:  false,

--- a/pkg/modules/libreoffice/routes.go
+++ b/pkg/modules/libreoffice/routes.go
@@ -25,16 +25,18 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 
 			// Let's get the data from the form and validate them.
 			var (
-				inputPaths       []string
-				landscape        bool
-				nativePageRanges string
-				exportFormFields bool
-				singlePageSheets bool
-				pdfa             string
-				pdfua            bool
-				nativePdfFormats bool
-				merge            bool
-				metadata         map[string]interface{}
+				inputPaths               []string
+				landscape                bool
+				nativePageRanges         string
+				exportFormFields         bool
+				singlePageSheets         bool
+				pdfa                     string
+				pdfua                    bool
+				nativePdfFormats         bool
+				merge                    bool
+				metadata                 map[string]interface{}
+				losslessImageCompression bool
+				reduceImageResolution    bool
 			)
 
 			err := ctx.FormData().
@@ -56,6 +58,8 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 					}
 					return nil
 				}).
+				Bool("losslessImageCompression", &losslessImageCompression, true).
+				Bool("reduceImageResolution", &reduceImageResolution, true).
 				Validate()
 			if err != nil {
 				return fmt.Errorf("validate form data: %w", err)
@@ -71,10 +75,12 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 			for i, inputPath := range inputPaths {
 				outputPaths[i] = ctx.GeneratePath(".pdf")
 				options := libreofficeapi.Options{
-					Landscape:        landscape,
-					PageRanges:       nativePageRanges,
-					ExportFormFields: exportFormFields,
-					SinglePageSheets: singlePageSheets,
+					Landscape:                landscape,
+					PageRanges:               nativePageRanges,
+					ExportFormFields:         exportFormFields,
+					SinglePageSheets:         singlePageSheets,
+					LosslessImageCompression: losslessImageCompression,
+					ReduceImageResolution:    reduceImageResolution,
 				}
 
 				if nativePdfFormats {

--- a/pkg/modules/libreoffice/routes.go
+++ b/pkg/modules/libreoffice/routes.go
@@ -45,7 +45,7 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 				String("nativePageRanges", &nativePageRanges, "").
 				Bool("exportFormFields", &exportFormFields, true).
 				Bool("singlePageSheets", &singlePageSheets, false).
-				Bool("losslessImageCompression", &losslessImageCompression, true).
+				Bool("losslessImageCompression", &losslessImageCompression, false).
 				Bool("reduceImageResolution", &reduceImageResolution, true).
 				String("pdfa", &pdfa, "").
 				Bool("pdfua", &pdfua, false).

--- a/pkg/modules/libreoffice/routes.go
+++ b/pkg/modules/libreoffice/routes.go
@@ -30,13 +30,13 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 				nativePageRanges         string
 				exportFormFields         bool
 				singlePageSheets         bool
+				losslessImageCompression bool
+				reduceImageResolution    bool
 				pdfa                     string
 				pdfua                    bool
 				nativePdfFormats         bool
 				merge                    bool
 				metadata                 map[string]interface{}
-				losslessImageCompression bool
-				reduceImageResolution    bool
 			)
 
 			err := ctx.FormData().
@@ -45,6 +45,8 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 				String("nativePageRanges", &nativePageRanges, "").
 				Bool("exportFormFields", &exportFormFields, true).
 				Bool("singlePageSheets", &singlePageSheets, false).
+				Bool("losslessImageCompression", &losslessImageCompression, true).
+				Bool("reduceImageResolution", &reduceImageResolution, true).
 				String("pdfa", &pdfa, "").
 				Bool("pdfua", &pdfua, false).
 				Bool("nativePdfFormats", &nativePdfFormats, true).
@@ -58,8 +60,6 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 					}
 					return nil
 				}).
-				Bool("losslessImageCompression", &losslessImageCompression, true).
-				Bool("reduceImageResolution", &reduceImageResolution, true).
 				Validate()
 			if err != nil {
 				return fmt.Errorf("validate form data: %w", err)


### PR DESCRIPTION
Allow the specifying of `losslessImageCompression` and `reduceImageResolution` form data items when calling the convert api endpoint (libreoffice)

These correspond to the ReduceImageResolution and UseLosslessCompression command line arguments to libre office
