### PR TITLE
ExportNotesInMargin allows to export comments in margin

### DIFF
--- a/pkg/modules/libreoffice/api/api.go
+++ b/pkg/modules/libreoffice/api/api.go
@@ -59,6 +59,10 @@ type Options struct {
 	// Optional
 	SinglePageSheets bool
 
+	// ExportNotesInMargin allows to export comments in margin.
+	// Optional
+	ExportNotesInMargin bool
+
 	// LosslessImageCompression allows turning lossless compression on or off
 	// to tweak image conversion performance.
 	// Optional
@@ -68,10 +72,6 @@ type Options struct {
 	// reduction to tweak image conversion performance.
 	// Optional
 	ReduceImageResolution bool
-
-	// ExportNotesInMargin allows to export comments in margin
-	// Optional
-	ExportNotesInMargin bool
 
 	// PdfFormats allows to convert the resulting PDF to PDF/A-1b, PDF/A-2b,
 	// PDF/A-3b and PDF/UA.

--- a/pkg/modules/libreoffice/api/api.go
+++ b/pkg/modules/libreoffice/api/api.go
@@ -69,6 +69,10 @@ type Options struct {
 	// Optional
 	ReduceImageResolution bool
 
+	// ExportNotesInMargin allows to export comments in margin
+	// Optional
+	ExportNotesInMargin bool
+
 	// PdfFormats allows to convert the resulting PDF to PDF/A-1b, PDF/A-2b,
 	// PDF/A-3b and PDF/UA.
 	// Optional.

--- a/pkg/modules/libreoffice/api/libreoffice.go
+++ b/pkg/modules/libreoffice/api/libreoffice.go
@@ -281,20 +281,16 @@ func (p *libreOfficeProcess) pdf(ctx context.Context, logger *zap.Logger, inputP
 		args = append(args, "--export", "SinglePageSheets=true")
 	}
 
+	if options.ExportNotesInMargin {
+		args = append(args, "--export", "ExportNotesInMargin=true")
+	}
+
 	if options.LosslessImageCompression {
 		args = append(args, "--export", "UseLosslessCompression=true")
 	}
 
 	if !options.ReduceImageResolution {
 		args = append(args, "--export", "ReduceImageResolution=false")
-	}
-
-	if options.ExportNotesInMargin {
-		args = append(
-			args,
-			"--export", "ExportNotes=true",
-			"--export", "ExportNotesInMargin=true",
-		)
 	}
 
 	switch options.PdfFormats.PdfA {

--- a/pkg/modules/libreoffice/api/libreoffice.go
+++ b/pkg/modules/libreoffice/api/libreoffice.go
@@ -289,6 +289,14 @@ func (p *libreOfficeProcess) pdf(ctx context.Context, logger *zap.Logger, inputP
 		args = append(args, "--export", "ReduceImageResolution=false")
 	}
 
+	if options.ExportNotesInMargin {
+		args = append(
+			args,
+			"--export", "ExportNotes=true",
+			"--export", "ExportNotesInMargin=true",
+		)
+	}
+
 	switch options.PdfFormats.PdfA {
 	case "":
 	case gotenberg.PdfA1b:

--- a/pkg/modules/libreoffice/api/libreoffice_test.go
+++ b/pkg/modules/libreoffice/api/libreoffice_test.go
@@ -452,6 +452,35 @@ func TestLibreOfficeProcess_pdf(t *testing.T) {
 			expectError:  false,
 		},
 		{
+			scenario: "success ExportNotesInMargin",
+			libreOffice: newLibreOfficeProcess(
+				libreOfficeArguments{
+					binPath:      os.Getenv("LIBREOFFICE_BIN_PATH"),
+					unoBinPath:   os.Getenv("UNOCONVERTER_BIN_PATH"),
+					startTimeout: 5 * time.Second,
+				},
+			),
+			fs: func() *gotenberg.FileSystem {
+				fs := gotenberg.NewFileSystem()
+
+				err := os.MkdirAll(fs.WorkingDirPath(), 0o755)
+				if err != nil {
+					t.Fatalf(fmt.Sprintf("expected no error but got: %v", err))
+				}
+
+				err = os.WriteFile(fmt.Sprintf("%s/document.txt", fs.WorkingDirPath()), []byte("ExportNotesInMargin"), 0o755)
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+
+				return fs
+			}(),
+			options:      Options{ExportNotesInMargin: true},
+			cancelledCtx: false,
+			start:        true,
+			expectError:  false,
+		},
+		{
 			scenario: "success LosslessImageCompression",
 			libreOffice: newLibreOfficeProcess(
 				libreOfficeArguments{
@@ -505,35 +534,6 @@ func TestLibreOfficeProcess_pdf(t *testing.T) {
 				return fs
 			}(),
 			options:      Options{ReduceImageResolution: false},
-			cancelledCtx: false,
-			start:        true,
-			expectError:  false,
-		},
-		{
-			scenario: "success ExportNotesInMargin",
-			libreOffice: newLibreOfficeProcess(
-				libreOfficeArguments{
-					binPath:      os.Getenv("LIBREOFFICE_BIN_PATH"),
-					unoBinPath:   os.Getenv("UNOCONVERTER_BIN_PATH"),
-					startTimeout: 5 * time.Second,
-				},
-			),
-			fs: func() *gotenberg.FileSystem {
-				fs := gotenberg.NewFileSystem()
-
-				err := os.MkdirAll(fs.WorkingDirPath(), 0o755)
-				if err != nil {
-					t.Fatalf(fmt.Sprintf("expected no error but got: %v", err))
-				}
-
-				err = os.WriteFile(fmt.Sprintf("%s/document.docx", fs.WorkingDirPath()), []byte("ExportNotesInMargin"), 0o755)
-				if err != nil {
-					t.Fatalf("expected no error but got: %v", err)
-				}
-
-				return fs
-			}(),
-			options:      Options{ExportNotesInMargin: true},
 			cancelledCtx: false,
 			start:        true,
 			expectError:  false,

--- a/pkg/modules/libreoffice/api/libreoffice_test.go
+++ b/pkg/modules/libreoffice/api/libreoffice_test.go
@@ -510,6 +510,35 @@ func TestLibreOfficeProcess_pdf(t *testing.T) {
 			expectError:  false,
 		},
 		{
+			scenario: "success ExportNotesInMargin",
+			libreOffice: newLibreOfficeProcess(
+				libreOfficeArguments{
+					binPath:      os.Getenv("LIBREOFFICE_BIN_PATH"),
+					unoBinPath:   os.Getenv("UNOCONVERTER_BIN_PATH"),
+					startTimeout: 5 * time.Second,
+				},
+			),
+			fs: func() *gotenberg.FileSystem {
+				fs := gotenberg.NewFileSystem()
+
+				err := os.MkdirAll(fs.WorkingDirPath(), 0o755)
+				if err != nil {
+					t.Fatalf(fmt.Sprintf("expected no error but got: %v", err))
+				}
+
+				err = os.WriteFile(fmt.Sprintf("%s/document.docx", fs.WorkingDirPath()), []byte("ExportNotesInMargin"), 0o755)
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+
+				return fs
+			}(),
+			options:      Options{ExportNotesInMargin: true},
+			cancelledCtx: false,
+			start:        true,
+			expectError:  false,
+		},
+		{
 			scenario: "success (PDF/A-1b)",
 			libreOffice: newLibreOfficeProcess(
 				libreOfficeArguments{

--- a/pkg/modules/libreoffice/routes.go
+++ b/pkg/modules/libreoffice/routes.go
@@ -30,9 +30,9 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 				nativePageRanges         string
 				exportFormFields         bool
 				singlePageSheets         bool
+				exportNotesInMargin      bool
 				losslessImageCompression bool
 				reduceImageResolution    bool
-				exportNotesInMargin      bool
 				pdfa                     string
 				pdfua                    bool
 				nativePdfFormats         bool
@@ -46,9 +46,9 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 				String("nativePageRanges", &nativePageRanges, "").
 				Bool("exportFormFields", &exportFormFields, true).
 				Bool("singlePageSheets", &singlePageSheets, false).
+				Bool("exportNotesInMargin", &exportNotesInMargin, false).
 				Bool("losslessImageCompression", &losslessImageCompression, false).
 				Bool("reduceImageResolution", &reduceImageResolution, true).
-				Bool("exportNotesInMargin", &exportNotesInMargin, false).
 				String("pdfa", &pdfa, "").
 				Bool("pdfua", &pdfua, false).
 				Bool("nativePdfFormats", &nativePdfFormats, true).
@@ -81,9 +81,9 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 					PageRanges:               nativePageRanges,
 					ExportFormFields:         exportFormFields,
 					SinglePageSheets:         singlePageSheets,
+					ExportNotesInMargin:      exportNotesInMargin,
 					LosslessImageCompression: losslessImageCompression,
 					ReduceImageResolution:    reduceImageResolution,
-					ExportNotesInMargin:      exportNotesInMargin,
 				}
 
 				if nativePdfFormats {

--- a/pkg/modules/libreoffice/routes.go
+++ b/pkg/modules/libreoffice/routes.go
@@ -32,6 +32,7 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 				singlePageSheets         bool
 				losslessImageCompression bool
 				reduceImageResolution    bool
+				exportNotesInMargin      bool
 				pdfa                     string
 				pdfua                    bool
 				nativePdfFormats         bool
@@ -47,6 +48,7 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 				Bool("singlePageSheets", &singlePageSheets, false).
 				Bool("losslessImageCompression", &losslessImageCompression, false).
 				Bool("reduceImageResolution", &reduceImageResolution, true).
+				Bool("exportNotesInMargin", &exportNotesInMargin, false).
 				String("pdfa", &pdfa, "").
 				Bool("pdfua", &pdfua, false).
 				Bool("nativePdfFormats", &nativePdfFormats, true).
@@ -81,6 +83,7 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 					SinglePageSheets:         singlePageSheets,
 					LosslessImageCompression: losslessImageCompression,
 					ReduceImageResolution:    reduceImageResolution,
+					ExportNotesInMargin:      exportNotesInMargin,
 				}
 
 				if nativePdfFormats {


### PR DESCRIPTION
Hello!
I needed to display comments in a margin... So I decided to add this option to your app.
I think this is a useful one :)

https://help.libreoffice.org/latest/en-US/text/shared/guide/pdf_params.html

![sw_text_with_comment](https://github.com/gotenberg/gotenberg/assets/7222512/059275cb-7dca-4d49-937f-69d974cb0f0f)
