### PR TITLE
fix(api): basic auth only for modules' routes

### DIFF
--- a/pkg/modules/api/api.go
+++ b/pkg/modules/api/api.go
@@ -411,13 +411,6 @@ func (a *Api) Start() error {
 		loggerMiddleware(a.logger, disableLoggingForPaths),
 	)
 
-	// Basic auth?
-	if a.basicAuthUsername != "" {
-		a.srv.Pre(
-			basicAuthMiddleware(a.basicAuthUsername, a.basicAuthPassword),
-		)
-	}
-
 	// Add the modules' middlewares in their respective stacks.
 	var externalMultipartMiddlewares []Middleware
 	for _, externalMiddleware := range a.externalMiddlewares {
@@ -436,6 +429,11 @@ func (a *Api) Start() error {
 	// Add the modules' routes and their specific middlewares.
 	for _, route := range a.routes {
 		var middlewares []echo.MiddlewareFunc
+
+		// Basic auth?
+		if a.basicAuthUsername != "" {
+			middlewares = append(middlewares, basicAuthMiddleware(a.basicAuthUsername, a.basicAuthPassword))
+		}
 
 		if route.IsMultipart {
 			middlewares = append(middlewares, contextMiddleware(a.fs, a.timeout))

--- a/pkg/modules/api/api_test.go
+++ b/pkg/modules/api/api_test.go
@@ -842,7 +842,6 @@ func TestApi_Start(t *testing.T) {
 			// health request.
 			recorder := httptest.NewRecorder()
 			healthRequest := httptest.NewRequest(http.MethodGet, "/health", nil)
-			healthRequest.SetBasicAuth(mod.basicAuthUsername, mod.basicAuthPassword)
 
 			mod.srv.ServeHTTP(recorder, healthRequest)
 			if recorder.Code != http.StatusOK {
@@ -851,7 +850,6 @@ func TestApi_Start(t *testing.T) {
 
 			// version request.
 			versionRequest := httptest.NewRequest(http.MethodGet, "/version", nil)
-			versionRequest.SetBasicAuth(mod.basicAuthUsername, mod.basicAuthPassword)
 
 			mod.srv.ServeHTTP(recorder, versionRequest)
 			if recorder.Code != http.StatusOK {


### PR DESCRIPTION
Fixes #909 

Only restrict modules' routes for now on (e.g., exclude /health and /version routes).