### PR TITLE
fix for go: download go1.23 toolchain not available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gotenberg/gotenberg/v8
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/alexliesenfeld/health v0.8.0


### PR DESCRIPTION
The problem appears when trying to run locally:
```bash
➜  gotenberg git:(main) ✗ go run cmd/gotenberg/main.go
go: downloading go1.23 (darwin/arm64)
go: download go1.23 for darwin/arm64: toolchain not available
```

The change is based on this answer: https://github.com/golang/go/issues/62278#issuecomment-1693538776