### PR TITLE
feat(chromium): add GenerateDocumentOutline option

### DIFF
--- a/pkg/modules/chromium/chromium.go
+++ b/pkg/modules/chromium/chromium.go
@@ -213,26 +213,31 @@ type PdfOptions struct {
 	// PreferCssPageSize defines whether to prefer page size as defined by CSS.
 	// If false, the content will be scaled to fit the paper size.
 	PreferCssPageSize bool
+
+	// GenerateDocumentOutline defines whether the document outline should be
+	// embedded into the PDF.
+	GenerateDocumentOutline bool
 }
 
 // DefaultPdfOptions returns the default values for PdfOptions.
 func DefaultPdfOptions() PdfOptions {
 	return PdfOptions{
-		Options:           DefaultOptions(),
-		Landscape:         false,
-		PrintBackground:   false,
-		Scale:             1.0,
-		SinglePage:        false,
-		PaperWidth:        8.5,
-		PaperHeight:       11,
-		MarginTop:         0.39,
-		MarginBottom:      0.39,
-		MarginLeft:        0.39,
-		MarginRight:       0.39,
-		PageRanges:        "",
-		HeaderTemplate:    "<html><head></head><body></body></html>",
-		FooterTemplate:    "<html><head></head><body></body></html>",
-		PreferCssPageSize: false,
+		Options:                 DefaultOptions(),
+		Landscape:               false,
+		PrintBackground:         false,
+		Scale:                   1.0,
+		SinglePage:              false,
+		PaperWidth:              8.5,
+		PaperHeight:             11,
+		MarginTop:               0.39,
+		MarginBottom:            0.39,
+		MarginLeft:              0.39,
+		MarginRight:             0.39,
+		PageRanges:              "",
+		HeaderTemplate:          "<html><head></head><body></body></html>",
+		FooterTemplate:          "<html><head></head><body></body></html>",
+		PreferCssPageSize:       false,
+		GenerateDocumentOutline: false,
 	}
 }
 

--- a/pkg/modules/chromium/routes.go
+++ b/pkg/modules/chromium/routes.go
@@ -205,6 +205,7 @@ func FormDataChromiumPdfOptions(ctx *api.Context) (*api.FormData, PdfOptions) {
 		pageRanges                                       string
 		headerTemplate, footerTemplate                   string
 		preferCssPageSize                                bool
+		generateDocumentOutline                          bool
 	)
 
 	form.
@@ -221,24 +222,26 @@ func FormDataChromiumPdfOptions(ctx *api.Context) (*api.FormData, PdfOptions) {
 		String("nativePageRanges", &pageRanges, defaultPdfOptions.PageRanges).
 		Content("header.html", &headerTemplate, defaultPdfOptions.HeaderTemplate).
 		Content("footer.html", &footerTemplate, defaultPdfOptions.FooterTemplate).
-		Bool("preferCssPageSize", &preferCssPageSize, defaultPdfOptions.PreferCssPageSize)
+		Bool("preferCssPageSize", &preferCssPageSize, defaultPdfOptions.PreferCssPageSize).
+		Bool("generateDocumentOutline", &generateDocumentOutline, defaultPdfOptions.GenerateDocumentOutline)
 
 	pdfOptions := PdfOptions{
-		Options:           options,
-		Landscape:         landscape,
-		PrintBackground:   printBackground,
-		Scale:             scale,
-		SinglePage:        singlePage,
-		PaperWidth:        paperWidth,
-		PaperHeight:       paperHeight,
-		MarginTop:         marginTop,
-		MarginBottom:      marginBottom,
-		MarginLeft:        marginLeft,
-		MarginRight:       marginRight,
-		PageRanges:        pageRanges,
-		HeaderTemplate:    headerTemplate,
-		FooterTemplate:    footerTemplate,
-		PreferCssPageSize: preferCssPageSize,
+		Options:                 options,
+		Landscape:               landscape,
+		PrintBackground:         printBackground,
+		Scale:                   scale,
+		SinglePage:              singlePage,
+		PaperWidth:              paperWidth,
+		PaperHeight:             paperHeight,
+		MarginTop:               marginTop,
+		MarginBottom:            marginBottom,
+		MarginLeft:              marginLeft,
+		MarginRight:             marginRight,
+		PageRanges:              pageRanges,
+		HeaderTemplate:          headerTemplate,
+		FooterTemplate:          footerTemplate,
+		PreferCssPageSize:       preferCssPageSize,
+		GenerateDocumentOutline: generateDocumentOutline,
 	}
 
 	return form, pdfOptions

--- a/pkg/modules/chromium/tasks.go
+++ b/pkg/modules/chromium/tasks.go
@@ -48,6 +48,7 @@ func printToPdfActionFunc(logger *zap.Logger, outputPath string, options PdfOpti
 			WithMarginRight(options.MarginRight).
 			WithPageRanges(pageRanges).
 			WithPreferCSSPageSize(options.PreferCssPageSize).
+			WithGenerateDocumentOutline(options.GenerateDocumentOutline).
 			// Does not seem to work.
 			// See https://github.com/gotenberg/gotenberg/issues/831.
 			WithGenerateTaggedPDF(false)


### PR DESCRIPTION
Resolves #1043

Added the option `generateDocumentOutline` for chromium PDF generation. Example usage:

```sh
curl \
  --request POST http://localhost:49153/forms/chromium/convert/url \
  --form url=https://liquidlearning.vercel.app/pdf/a00Mn00000PmwksIAB \
  --form generateDocumentOutline=true \
  -o example.pdf
```

Here's the PDF produced when printing the [Mozart Wikipedia Page](https://en.wikipedia.org/wiki/Wolfgang_Amadeus_Mozart?variant=zh-cn#Appearance_and_character)
- [example.pdf](https://github.com/user-attachments/files/17794572/example.pdf)

Key point being the outline generated on the left sidebar (firefox PDF preview):

![image](https://github.com/user-attachments/assets/28be2bbf-f3cf-4257-9448-d8ad9249cd96)
