### PR TITLE
Metadata typos

### DIFF
--- a/pkg/modules/pdfengines/multi.go
+++ b/pkg/modules/pdfengines/multi.go
@@ -12,11 +12,11 @@ import (
 )
 
 type multiPdfEngines struct {
-	mergeEngines       []gotenberg.PdfEngine
-	splitEngines       []gotenberg.PdfEngine
-	convertEngines     []gotenberg.PdfEngine
-	readMedataEngines  []gotenberg.PdfEngine
-	writeMedataEngines []gotenberg.PdfEngine
+	mergeEngines         []gotenberg.PdfEngine
+	splitEngines         []gotenberg.PdfEngine
+	convertEngines       []gotenberg.PdfEngine
+	readMetadataEngines  []gotenberg.PdfEngine
+	writeMetadataEngines []gotenberg.PdfEngine
 }
 
 func newMultiPdfEngines(
@@ -24,14 +24,14 @@ func newMultiPdfEngines(
 	splitEngines,
 	convertEngines,
 	readMetadataEngines,
-	writeMedataEngines []gotenberg.PdfEngine,
+	writeMetadataEngines []gotenberg.PdfEngine,
 ) *multiPdfEngines {
 	return &multiPdfEngines{
 		mergeEngines:       mergeEngines,
 		splitEngines:       splitEngines,
 		convertEngines:     convertEngines,
-		readMedataEngines:  readMetadataEngines,
-		writeMedataEngines: writeMedataEngines,
+		readMetadataEngines:  readMetadataEngines,
+		writeMetadataEngines: writeMetadataEngines,
 	}
 }
 
@@ -132,16 +132,16 @@ func (multi *multiPdfEngines) ReadMetadata(ctx context.Context, logger *zap.Logg
 	var err error
 	var mu sync.Mutex // to safely append errors.
 
-	resultChan := make(chan readMetadataResult, len(multi.readMedataEngines))
+	resultChan := make(chan readMetadataResult, len(multi.readMetadataEngines))
 
-	for _, engine := range multi.readMedataEngines {
+	for _, engine := range multi.readMetadataEngines {
 		go func(engine gotenberg.PdfEngine) {
 			metadata, err := engine.ReadMetadata(ctx, logger, inputPath)
 			resultChan <- readMetadataResult{metadata: metadata, err: err}
 		}(engine)
 	}
 
-	for range multi.readMedataEngines {
+	for range multi.readMetadataEngines {
 		select {
 		case result := <-resultChan:
 			if result.err != nil {
@@ -163,7 +163,7 @@ func (multi *multiPdfEngines) WriteMetadata(ctx context.Context, logger *zap.Log
 	var err error
 	errChan := make(chan error, 1)
 
-	for _, engine := range multi.writeMedataEngines {
+	for _, engine := range multi.writeMetadataEngines {
 		go func(engine gotenberg.PdfEngine) {
 			errChan <- engine.WriteMetadata(ctx, logger, metadata, inputPath)
 		}(engine)

--- a/pkg/modules/pdfengines/multi_test.go
+++ b/pkg/modules/pdfengines/multi_test.go
@@ -295,7 +295,7 @@ func TestMultiPdfEngines_ReadMetadata(t *testing.T) {
 		{
 			scenario: "nominal behavior",
 			engine: &multiPdfEngines{
-				readMedataEngines: []gotenberg.PdfEngine{
+				readMetadataEngines: []gotenberg.PdfEngine{
 					&gotenberg.PdfEngineMock{
 						ReadMetadataMock: func(ctx context.Context, logger *zap.Logger, inputPath string) (map[string]interface{}, error) {
 							return make(map[string]interface{}), nil
@@ -308,7 +308,7 @@ func TestMultiPdfEngines_ReadMetadata(t *testing.T) {
 		{
 			scenario: "at least one engine does not return an error",
 			engine: &multiPdfEngines{
-				readMedataEngines: []gotenberg.PdfEngine{
+				readMetadataEngines: []gotenberg.PdfEngine{
 					&gotenberg.PdfEngineMock{
 						ReadMetadataMock: func(ctx context.Context, logger *zap.Logger, inputPath string) (map[string]interface{}, error) {
 							return nil, errors.New("foo")
@@ -326,7 +326,7 @@ func TestMultiPdfEngines_ReadMetadata(t *testing.T) {
 		{
 			scenario: "all engines return an error",
 			engine: &multiPdfEngines{
-				readMedataEngines: []gotenberg.PdfEngine{
+				readMetadataEngines: []gotenberg.PdfEngine{
 					&gotenberg.PdfEngineMock{
 						ReadMetadataMock: func(ctx context.Context, logger *zap.Logger, inputPath string) (map[string]interface{}, error) {
 							return nil, errors.New("foo")
@@ -345,7 +345,7 @@ func TestMultiPdfEngines_ReadMetadata(t *testing.T) {
 		{
 			scenario: "context expired",
 			engine: &multiPdfEngines{
-				readMedataEngines: []gotenberg.PdfEngine{
+				readMetadataEngines: []gotenberg.PdfEngine{
 					&gotenberg.PdfEngineMock{
 						ReadMetadataMock: func(ctx context.Context, logger *zap.Logger, inputPath string) (map[string]interface{}, error) {
 							return make(map[string]interface{}), nil
@@ -386,7 +386,7 @@ func TestMultiPdfEngines_WriteMetadata(t *testing.T) {
 		{
 			scenario: "nominal behavior",
 			engine: &multiPdfEngines{
-				writeMedataEngines: []gotenberg.PdfEngine{
+				writeMetadataEngines: []gotenberg.PdfEngine{
 					&gotenberg.PdfEngineMock{
 						WriteMetadataMock: func(ctx context.Context, logger *zap.Logger, metadata map[string]interface{}, inputPath string) error {
 							return nil
@@ -399,7 +399,7 @@ func TestMultiPdfEngines_WriteMetadata(t *testing.T) {
 		{
 			scenario: "at least one engine does not return an error",
 			engine: &multiPdfEngines{
-				writeMedataEngines: []gotenberg.PdfEngine{
+				writeMetadataEngines: []gotenberg.PdfEngine{
 					&gotenberg.PdfEngineMock{
 						WriteMetadataMock: func(ctx context.Context, logger *zap.Logger, metadata map[string]interface{}, inputPath string) error {
 							return errors.New("foo")
@@ -417,7 +417,7 @@ func TestMultiPdfEngines_WriteMetadata(t *testing.T) {
 		{
 			scenario: "all engines return an error",
 			engine: &multiPdfEngines{
-				writeMedataEngines: []gotenberg.PdfEngine{
+				writeMetadataEngines: []gotenberg.PdfEngine{
 					&gotenberg.PdfEngineMock{
 						WriteMetadataMock: func(ctx context.Context, logger *zap.Logger, metadata map[string]interface{}, inputPath string) error {
 							return errors.New("foo")
@@ -436,7 +436,7 @@ func TestMultiPdfEngines_WriteMetadata(t *testing.T) {
 		{
 			scenario: "context expired",
 			engine: &multiPdfEngines{
-				writeMedataEngines: []gotenberg.PdfEngine{
+				writeMetadataEngines: []gotenberg.PdfEngine{
 					&gotenberg.PdfEngineMock{
 						WriteMetadataMock: func(ctx context.Context, logger *zap.Logger, metadata map[string]interface{}, inputPath string) error {
 							return nil

--- a/pkg/modules/pdfengines/pdfengines.go
+++ b/pkg/modules/pdfengines/pdfengines.go
@@ -27,13 +27,13 @@ func init() {
 // the [api.Router] interface to expose relevant PDF processing routes if
 // enabled.
 type PdfEngines struct {
-	mergeNames        []string
-	splitNames        []string
-	convertNames      []string
-	readMetadataNames []string
-	writeMedataNames  []string
-	engines           []gotenberg.PdfEngine
-	disableRoutes     bool
+	mergeNames         []string
+	splitNames         []string
+	convertNames       []string
+	readMetadataNames  []string
+	writeMetadataNames []string
+	engines            []gotenberg.PdfEngine
+	disableRoutes      bool
 }
 
 // Descriptor returns a PdfEngines' module descriptor.
@@ -116,9 +116,9 @@ func (mod *PdfEngines) Provision(ctx *gotenberg.Context) error {
 		mod.readMetadataNames = readMetadataNames
 	}
 
-	mod.writeMedataNames = defaultNames
+	mod.writeMetadataNames = defaultNames
 	if len(writeMetadataNames) > 0 {
-		mod.writeMedataNames = writeMetadataNames
+		mod.writeMetadataNames = writeMetadataNames
 	}
 
 	return nil
@@ -172,7 +172,7 @@ func (mod *PdfEngines) Validate() error {
 	findNonExistingEngines(mod.splitNames)
 	findNonExistingEngines(mod.convertNames)
 	findNonExistingEngines(mod.readMetadataNames)
-	findNonExistingEngines(mod.writeMedataNames)
+	findNonExistingEngines(mod.writeMetadataNames)
 
 	if len(nonExistingEngines) == 0 {
 		return nil
@@ -189,7 +189,7 @@ func (mod *PdfEngines) SystemMessages() []string {
 		fmt.Sprintf("split engines - %s", strings.Join(mod.splitNames[:], " ")),
 		fmt.Sprintf("convert engines - %s", strings.Join(mod.convertNames[:], " ")),
 		fmt.Sprintf("read metadata engines - %s", strings.Join(mod.readMetadataNames[:], " ")),
-		fmt.Sprintf("write medata engines - %s", strings.Join(mod.writeMedataNames[:], " ")),
+		fmt.Sprintf("write metadata engines - %s", strings.Join(mod.writeMetadataNames[:], " ")),
 	}
 }
 
@@ -214,7 +214,7 @@ func (mod *PdfEngines) PdfEngine() (gotenberg.PdfEngine, error) {
 		engines(mod.splitNames),
 		engines(mod.convertNames),
 		engines(mod.readMetadataNames),
-		engines(mod.writeMedataNames),
+		engines(mod.writeMetadataNames),
 	), nil
 }
 

--- a/pkg/modules/pdfengines/pdfengines_test.go
+++ b/pkg/modules/pdfengines/pdfengines_test.go
@@ -193,7 +193,7 @@ func TestPdfEngines_Provision(t *testing.T) {
 				t.Fatalf("expected %d read metadata names but got %d", len(tc.expectedReadMetadataPdfEngines), len(mod.readMetadataNames))
 			}
 
-			if len(tc.expectedWriteMetadataPdfEngines) != len(mod.writeMedataNames) {
+			if len(tc.expectedWriteMetadataPdfEngines) != len(mod.writeMetadataNames) {
 				t.Fatalf("expected %d write metadata names but got %d", len(tc.expectedWriteMetadataPdfEngines), len(mod.writeMedataNames))
 			}
 
@@ -221,7 +221,7 @@ func TestPdfEngines_Provision(t *testing.T) {
 				}
 			}
 
-			for index, name := range mod.writeMedataNames {
+			for index, name := range mod.writeMetadataNames {
 				if name != tc.expectedWriteMetadataPdfEngines[index] {
 					t.Fatalf("expected write metadat name at index %d to be %s, but got: %s", index, name, tc.expectedWriteMetadataPdfEngines[index])
 				}
@@ -289,11 +289,11 @@ func TestPdfEngines_Validate(t *testing.T) {
 	} {
 		t.Run(tc.scenario, func(t *testing.T) {
 			mod := PdfEngines{
-				mergeNames:        tc.names,
-				convertNames:      tc.names,
-				readMetadataNames: tc.names,
-				writeMedataNames:  tc.names,
-				engines:           tc.engines,
+				mergeNames:         tc.names,
+				convertNames:       tc.names,
+				readMetadataNames:  tc.names,
+				writeMetadataNames: tc.names,
+				engines:            tc.engines,
 			}
 
 			err := mod.Validate()
@@ -315,7 +315,7 @@ func TestPdfEngines_SystemMessages(t *testing.T) {
 	mod.splitNames = []string{"foo", "bar"}
 	mod.convertNames = []string{"foo", "bar"}
 	mod.readMetadataNames = []string{"foo", "bar"}
-	mod.writeMedataNames = []string{"foo", "bar"}
+	mod.writeMetadataNames = []string{"foo", "bar"}
 
 	messages := mod.SystemMessages()
 	if len(messages) != 5 {
@@ -327,7 +327,7 @@ func TestPdfEngines_SystemMessages(t *testing.T) {
 		fmt.Sprintf("split engines - %s", strings.Join(mod.splitNames[:], " ")),
 		fmt.Sprintf("convert engines - %s", strings.Join(mod.convertNames[:], " ")),
 		fmt.Sprintf("read metadata engines - %s", strings.Join(mod.readMetadataNames[:], " ")),
-		fmt.Sprintf("write medata engines - %s", strings.Join(mod.writeMedataNames[:], " ")),
+		fmt.Sprintf("write metadata engines - %s", strings.Join(mod.writeMetadataNames[:], " ")),
 	}
 
 	for i, message := range messages {
@@ -339,11 +339,11 @@ func TestPdfEngines_SystemMessages(t *testing.T) {
 
 func TestPdfEngines_PdfEngine(t *testing.T) {
 	mod := PdfEngines{
-		mergeNames:        []string{"foo", "bar"},
-		splitNames:        []string{"foo", "bar"},
-		convertNames:      []string{"foo", "bar"},
-		readMetadataNames: []string{"foo", "bar"},
-		writeMedataNames:  []string{"foo", "bar"},
+		mergeNames:         []string{"foo", "bar"},
+		splitNames:         []string{"foo", "bar"},
+		convertNames:       []string{"foo", "bar"},
+		readMetadataNames:  []string{"foo", "bar"},
+		writeMetadataNames: []string{"foo", "bar"},
 		engines: func() []gotenberg.PdfEngine {
 			engine1 := &struct {
 				gotenberg.ModuleMock


### PR DESCRIPTION
Small PR to fix both log and code related typos on the word "metadata".