### PR TITLE
feat(api): added dummy root route pointing to docs

### DIFF
--- a/pkg/modules/api/api.go
+++ b/pkg/modules/api/api.go
@@ -483,18 +483,20 @@ func (a *Api) Start() error {
 		)
 	}
 
-	// Root routes.
+	// Root route.
 	a.srv.GET(
-	    a.rootPath, 
-	    func(c echo.Context) error {
-		c.HTML(http.StatusOK, `Hey, this Gotenberg no UI, it's an API. Head to the <a href="https://gotenberg.dev">documentation</a> to learn how to interact with it 🚀`)
-	    },
+		a.rootPath, 
+		func(c echo.Context) error {
+				return c.HTML(http.StatusOK, `Hey, this Gotenberg has no UI, it's an API. Head to the <a href="https://gotenberg.dev">documentation</a> to learn how to interact with it 🚀`)
+		},
 	)
+
+	// Favicon route.
 	a.srv.GET(
-	    fmt.Sprintf("%sfavicon.ico", a.rootPath) 
-	    func(c echo.Context) error {
-		return c.NoContent(http.StatusNoContent)
-	    },
+		fmt.Sprintf("%sfavicon.ico", a.rootPath),
+		func(c echo.Context) error {
+			return c.NoContent(http.StatusNoContent)
+		},
 	)
 
 	// Let's not forget the health check routes...

--- a/pkg/modules/api/api.go
+++ b/pkg/modules/api/api.go
@@ -485,9 +485,9 @@ func (a *Api) Start() error {
 
 	// Root route.
 	a.srv.GET(
-		a.rootPath, 
+		a.rootPath,
 		func(c echo.Context) error {
-				return c.HTML(http.StatusOK, `Hey, this Gotenberg has no UI, it's an API. Head to the <a href="https://gotenberg.dev">documentation</a> to learn how to interact with it 🚀`)
+			return c.HTML(http.StatusOK, `Hey, this Gotenberg has no UI, it's an API. Head to the <a href="https://gotenberg.dev">documentation</a> to learn how to interact with it 🚀`)
 		},
 	)
 

--- a/pkg/modules/api/api.go
+++ b/pkg/modules/api/api.go
@@ -483,6 +483,18 @@ func (a *Api) Start() error {
 		)
 	}
 
+	// Root route
+	a.srv.GET(a.rootPath, func(c echo.Context) error {
+		html := `
+		<p>
+			Hey, Gotenberg has no UI, it's an API. Head to the
+			<a href="https://gotenberg.dev" target="_blank">documentation</a>
+			to learn how to interact with it 🚀
+		</p>
+	`
+		return c.HTML(http.StatusOK, html)
+	})
+
 	// Let's not forget the health check routes...
 	checks := append(a.healthChecks, health.WithTimeout(a.timeout))
 	checker := health.NewChecker(checks...)

--- a/pkg/modules/api/api.go
+++ b/pkg/modules/api/api.go
@@ -493,7 +493,7 @@ func (a *Api) Start() error {
 
 	// Favicon route.
 	a.srv.GET(
-		fmt.Sprintf("%sfavicon.ico", a.rootPath),
+		fmt.Sprintf("%s%s", a.rootPath, "favicon.ico"),
 		func(c echo.Context) error {
 			return c.NoContent(http.StatusNoContent)
 		},

--- a/pkg/modules/api/api.go
+++ b/pkg/modules/api/api.go
@@ -483,17 +483,19 @@ func (a *Api) Start() error {
 		)
 	}
 
-	// Root route
-	a.srv.GET(a.rootPath, func(c echo.Context) error {
-		html := `
-		<p>
-			Hey, Gotenberg has no UI, it's an API. Head to the
-			<a href="https://gotenberg.dev" target="_blank">documentation</a>
-			to learn how to interact with it 🚀
-		</p>
-	`
-		return c.HTML(http.StatusOK, html)
-	})
+	// Root routes.
+	a.srv.GET(
+	    a.rootPath, 
+	    func(c echo.Context) error {
+		c.HTML(http.StatusOK, `Hey, this Gotenberg no UI, it's an API. Head to the <a href="https://gotenberg.dev">documentation</a> to learn how to interact with it 🚀`)
+	    },
+	)
+	a.srv.GET(
+	    fmt.Sprintf("%sfavicon.ico", a.rootPath) 
+	    func(c echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	    },
+	)
 
 	// Let's not forget the health check routes...
 	checks := append(a.healthChecks, health.WithTimeout(a.timeout))

--- a/pkg/modules/api/api_test.go
+++ b/pkg/modules/api/api_test.go
@@ -875,6 +875,12 @@ func TestApi_Start(t *testing.T) {
 				t.Errorf("expected %d status code but got %d", http.StatusOK, recorder.Code)
 			}
 
+			faviconRequest := httptest.NewRequest(http.MethodGet, "/favicon.ico", nil)
+			mod.srv.ServeHTTP(recorder, faviconRequest)
+			if recorder.Code != http.StatusNoContent {
+				t.Errorf("expected %d status code but got %d", http.StatusNoContent, recorder.Code)
+			}
+
 			// health requests.
 			healthGetRequest := httptest.NewRequest(http.MethodGet, "/health", nil)
 			mod.srv.ServeHTTP(recorder, healthGetRequest)

--- a/pkg/modules/api/api_test.go
+++ b/pkg/modules/api/api_test.go
@@ -874,6 +874,7 @@ func TestApi_Start(t *testing.T) {
 				t.Errorf("expected %d status code but got %d", http.StatusOK, recorder.Code)
 			}
 
+			// favicon request.
 			recorder = httptest.NewRecorder()
 			faviconRequest := httptest.NewRequest(http.MethodGet, "/favicon.ico", nil)
 			mod.srv.ServeHTTP(recorder, faviconRequest)

--- a/pkg/modules/api/api_test.go
+++ b/pkg/modules/api/api_test.go
@@ -866,9 +866,16 @@ func TestApi_Start(t *testing.T) {
 				return
 			}
 
-			// health requests.
 			recorder := httptest.NewRecorder()
 
+			// root request.
+			rootRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+			mod.srv.ServeHTTP(recorder, rootRequest)
+			if recorder.Code != http.StatusOK {
+				t.Errorf("expected %d status code but got %d", http.StatusOK, recorder.Code)
+			}
+
+			// health requests.
 			healthGetRequest := httptest.NewRequest(http.MethodGet, "/health", nil)
 			mod.srv.ServeHTTP(recorder, healthGetRequest)
 			if recorder.Code != http.StatusOK {

--- a/pkg/modules/api/api_test.go
+++ b/pkg/modules/api/api_test.go
@@ -866,15 +866,15 @@ func TestApi_Start(t *testing.T) {
 				return
 			}
 
-			recorder := httptest.NewRecorder()
-
 			// root request.
+			recorder := httptest.NewRecorder()
 			rootRequest := httptest.NewRequest(http.MethodGet, "/", nil)
 			mod.srv.ServeHTTP(recorder, rootRequest)
 			if recorder.Code != http.StatusOK {
 				t.Errorf("expected %d status code but got %d", http.StatusOK, recorder.Code)
 			}
 
+			recorder = httptest.NewRecorder()
 			faviconRequest := httptest.NewRequest(http.MethodGet, "/favicon.ico", nil)
 			mod.srv.ServeHTTP(recorder, faviconRequest)
 			if recorder.Code != http.StatusNoContent {
@@ -882,12 +882,14 @@ func TestApi_Start(t *testing.T) {
 			}
 
 			// health requests.
+			recorder = httptest.NewRecorder()
 			healthGetRequest := httptest.NewRequest(http.MethodGet, "/health", nil)
 			mod.srv.ServeHTTP(recorder, healthGetRequest)
 			if recorder.Code != http.StatusOK {
 				t.Errorf("expected %d status code but got %d", http.StatusOK, recorder.Code)
 			}
 
+			recorder = httptest.NewRecorder()
 			healthHeadRequest := httptest.NewRequest(http.MethodHead, "/health", nil)
 			mod.srv.ServeHTTP(recorder, healthHeadRequest)
 			if recorder.Code != http.StatusOK {
@@ -895,6 +897,7 @@ func TestApi_Start(t *testing.T) {
 			}
 
 			// version request.
+			recorder = httptest.NewRecorder()
 			versionRequest := httptest.NewRequest(http.MethodGet, "/version", nil)
 			mod.srv.ServeHTTP(recorder, versionRequest)
 			if recorder.Code != http.StatusOK {


### PR DESCRIPTION
Added the root route, `/`:

![feat-root-route](https://github.com/user-attachments/assets/d2a8cd96-ec40-4764-9a13-bbb98e0c579e)

similar to what is present at https://demo.gotenberg.dev:

![demo-root-route](https://github.com/user-attachments/assets/2b76b9ce-c9e1-445c-9f3a-21cb00a017af)

---

Only a minor issue, but users can get confused if nothing is displayed at the root URL, e.g. in [this comment](https://github.com/coollabsio/coolify/pull/4759#issuecomment-2589839139).

This could occur when someone is trialing the software using a "one-click deploy" feature/template, e.g. offered by Coolify/Dokploy.
Also potentially useful for basic/automatic health-check services that may not use the `/heath` route.

I believe it's not uncommon to avoid having `/` as 404 - e.g. here's what conduit displays at `/`:

![conduit](https://github.com/user-attachments/assets/9a356c75-7803-41c4-8e48-2af320b626a0)

---