### PR TITLE
fix: correctly map GCP structured log keys

### DIFF
--- a/pkg/modules/logging/logging.go
+++ b/pkg/modules/logging/logging.go
@@ -198,16 +198,12 @@ func newLogEncoder(format string, gcpSeverity bool) (zapcore.Encoder, error) {
 
 		if gcpSeverity {
 			encCfg.EncodeLevel = gcpSeverityEncoder
+			// Those only make sense in JSON.
 			encCfg.TimeKey = "time"
 			encCfg.LevelKey = "severity"
-			encCfg.NameKey = "logger"
-			encCfg.CallerKey = "caller"
 			encCfg.MessageKey = "message"
-			encCfg.StacktraceKey = "stacktrace"
-			encCfg.LineEnding = zapcore.DefaultLineEnding
-			encCfg.EncodeTime = zapcore.RFC3339TimeEncoder
+			encCfg.EncodeTime = zapcore.ISO8601TimeEncoder
 			encCfg.EncodeDuration = zapcore.MillisDurationEncoder
-			encCfg.EncodeCaller = zapcore.ShortCallerEncoder
 		}
 	}
 

--- a/pkg/modules/logging/logging.go
+++ b/pkg/modules/logging/logging.go
@@ -198,6 +198,16 @@ func newLogEncoder(format string, gcpSeverity bool) (zapcore.Encoder, error) {
 
 		if gcpSeverity {
 			encCfg.EncodeLevel = gcpSeverityEncoder
+			encCfg.TimeKey = "time"
+			encCfg.LevelKey = "severity"
+			encCfg.NameKey = "logger"
+			encCfg.CallerKey = "caller"
+			encCfg.MessageKey = "message"
+			encCfg.StacktraceKey = "stacktrace"
+			encCfg.LineEnding = zapcore.DefaultLineEnding
+			encCfg.EncodeTime = zapcore.RFC3339TimeEncoder
+			encCfg.EncodeDuration = zapcore.MillisDurationEncoder
+			encCfg.EncodeCaller = zapcore.ShortCallerEncoder
 		}
 	}
 


### PR DESCRIPTION
The new GCP functionality was missing the mapping of severity, time, logger, caller, message and stack trace keys as well as some encoding options specific to structured logging to GCP. 

This PR addresses it based on this issue: https://github.com/uber-go/zap/issues/1095