### PR TITLE
fix(webhook): content-disposition header

### DIFF
--- a/pkg/modules/webhook/middleware.go
+++ b/pkg/modules/webhook/middleware.go
@@ -239,9 +239,9 @@ func webhookMiddleware(w *Webhook) api.Middleware {
 						}
 
 						headers := map[string]string{
-							echo.HeaderContentType:        http.DetectContentType(fileHeader),
-							echo.HeaderContentLength:      strconv.FormatInt(fileStat.Size(), 10),
-							traceHeader:                   trace,
+							echo.HeaderContentType:   http.DetectContentType(fileHeader),
+							echo.HeaderContentLength: strconv.FormatInt(fileStat.Size(), 10),
+							traceHeader:              trace,
 						}
 
 						// Allow for custom Content-Disposition header.

--- a/pkg/modules/webhook/middleware.go
+++ b/pkg/modules/webhook/middleware.go
@@ -239,10 +239,15 @@ func webhookMiddleware(w *Webhook) api.Middleware {
 						}
 
 						headers := map[string]string{
-							echo.HeaderContentDisposition: fmt.Sprintf("attachement; filename=%q", ctx.OutputFilename(outputPath)),
 							echo.HeaderContentType:        http.DetectContentType(fileHeader),
 							echo.HeaderContentLength:      strconv.FormatInt(fileStat.Size(), 10),
 							traceHeader:                   trace,
+						}
+
+						// if Content-Disposition is not set in extraHttpHeaders, we set it.
+						default_disposition := fmt.Sprintf("attachment; filename=%q", ctx.OutputFilename(outputPath))
+						if _, ok := extraHttpHeaders[echo.HeaderContentDisposition]; !ok {
+							headers[echo.HeaderContentDisposition] = default_disposition
 						}
 
 						// Send the output file to the webhook.

--- a/pkg/modules/webhook/middleware.go
+++ b/pkg/modules/webhook/middleware.go
@@ -244,10 +244,11 @@ func webhookMiddleware(w *Webhook) api.Middleware {
 							traceHeader:                   trace,
 						}
 
-						// if Content-Disposition is not set in extraHttpHeaders, we set it.
-						default_disposition := fmt.Sprintf("attachment; filename=%q", ctx.OutputFilename(outputPath))
-						if _, ok := extraHttpHeaders[echo.HeaderContentDisposition]; !ok {
-							headers[echo.HeaderContentDisposition] = default_disposition
+						// Allow for custom Content-Disposition header.
+						// See https://github.com/gotenberg/gotenberg/issues/1165.
+						_, ok := extraHttpHeaders[echo.HeaderContentDisposition]
+						if !ok {
+							headers[echo.HeaderContentDisposition] = fmt.Sprintf("attachment; filename=%q", ctx.OutputFilename(outputPath))
 						}
 
 						// Send the output file to the webhook.


### PR DESCRIPTION
Fixes the spelling of `attachment` in the default content-disposition header in the webhook middleware. Also allows a custom content-disposition to be specified via the extraHttpHeaders.

Closes #1165 