### PR TITLE
only build debug info when log level is debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ CHROMIUM_CLEAR_CACHE=false
 CHROMIUM_CLEAR_COOKIES=false
 CHROMIUM_DISABLE_JAVASCRIPT=false
 CHROMIUM_DISABLE_ROUTES=false
+GOTENBERG_BUILD_DEBUG_DATA=true
 LIBREOFFICE_RESTART_AFTER=10
 LIBREOFFICE_MAX_QUEUE_SIZE=0
 LIBREOFFICE_AUTO_START=false
@@ -123,6 +124,7 @@ run: ## Start a Gotenberg container
 	--chromium-clear-cookies=$(CHROMIUM_CLEAR_COOKIES) \
 	--chromium-disable-javascript=$(CHROMIUM_DISABLE_JAVASCRIPT) \
 	--chromium-disable-routes=$(CHROMIUM_DISABLE_ROUTES) \
+	--gotenberg-build-debug-data=$(GOTENBERG_BUILD_DEBUG_DATA) \
 	--libreoffice-restart-after=$(LIBREOFFICE_RESTART_AFTER) \
 	--libreoffice-max-queue-size=$(LIBREOFFICE_MAX_QUEUE_SIZE) \
 	--libreoffice-auto-start=$(LIBREOFFICE_AUTO_START) \

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ build: ## Build the Gotenberg's Docker image
 	-f $(DOCKERFILE) $(DOCKER_BUILD_CONTEXT)
 
 GOTENBERG_GRACEFUL_SHUTDOWN_DURATION=30s
+GOTENBERG_BUILD_DEBUG_DATA=true
 API_PORT=3000
 API_PORT_FROM_ENV=
 API_BIND_IP=
@@ -52,7 +53,6 @@ CHROMIUM_CLEAR_CACHE=false
 CHROMIUM_CLEAR_COOKIES=false
 CHROMIUM_DISABLE_JAVASCRIPT=false
 CHROMIUM_DISABLE_ROUTES=false
-GOTENBERG_BUILD_DEBUG_DATA=true
 LIBREOFFICE_RESTART_AFTER=10
 LIBREOFFICE_MAX_QUEUE_SIZE=0
 LIBREOFFICE_AUTO_START=false
@@ -92,6 +92,7 @@ run: ## Start a Gotenberg container
 	$(DOCKER_REGISTRY)/$(DOCKER_REPOSITORY):$(GOTENBERG_VERSION) \
 	gotenberg \
 	--gotenberg-graceful-shutdown-duration=$(GOTENBERG_GRACEFUL_SHUTDOWN_DURATION) \
+	--gotenberg-build-debug-data=$(GOTENBERG_BUILD_DEBUG_DATA) \	
 	--api-port=$(API_PORT) \
 	--api-port-from-env=$(API_PORT_FROM_ENV) \
 	--api-bind-ip=$(API_BIND_IP) \
@@ -124,7 +125,6 @@ run: ## Start a Gotenberg container
 	--chromium-clear-cookies=$(CHROMIUM_CLEAR_COOKIES) \
 	--chromium-disable-javascript=$(CHROMIUM_DISABLE_JAVASCRIPT) \
 	--chromium-disable-routes=$(CHROMIUM_DISABLE_ROUTES) \
-	--gotenberg-build-debug-data=$(GOTENBERG_BUILD_DEBUG_DATA) \
 	--libreoffice-restart-after=$(LIBREOFFICE_RESTART_AFTER) \
 	--libreoffice-max-queue-size=$(LIBREOFFICE_MAX_QUEUE_SIZE) \
 	--libreoffice-auto-start=$(LIBREOFFICE_AUTO_START) \

--- a/cmd/gotenberg.go
+++ b/cmd/gotenberg.go
@@ -137,8 +137,10 @@ func Run() {
 		}(l.(gotenberg.SystemLogger))
 	}
 
-	// Build the debug data.
-	gotenberg.BuildDebug(ctx)
+	if parsedFlags.MustString("log-level") == "debug" {
+		// Build the debug data.
+		gotenberg.BuildDebug(ctx)
+	}
 
 	quit := make(chan os.Signal, 1)
 

--- a/cmd/gotenberg.go
+++ b/cmd/gotenberg.go
@@ -41,6 +41,7 @@ func Run() {
 	// Create the root FlagSet and adds the modules flags to it.
 	fs := flag.NewFlagSet("gotenberg", flag.ExitOnError)
 	fs.Duration("gotenberg-graceful-shutdown-duration", time.Duration(30)*time.Second, "Set the graceful shutdown duration")
+	fs.Bool("gotenberg-build-debug-data", true, "Set if build data is needed")
 
 	descriptors := gotenberg.GetModuleDescriptors()
 	var modsInfo string
@@ -137,7 +138,7 @@ func Run() {
 		}(l.(gotenberg.SystemLogger))
 	}
 
-	if parsedFlags.MustString("log-level") == "debug" {
+	if parsedFlags.MustBool("gotenberg-build-debug-data") {
 		// Build the debug data.
 		gotenberg.BuildDebug(ctx)
 	}

--- a/test/integration/features/debug.feature
+++ b/test/integration/features/debug.feature
@@ -120,6 +120,23 @@ Feature: /debug
       }
       """
 
+  Scenario: GET /debug (Build Debug Data Disabled)
+    Given I have a Gotenberg container with the following environment variable(s):
+      | GOTENBERG_BUILD_DEBUG_DATA | false |
+    When I make a "GET" request to Gotenberg at the "/debug" endpoint
+    Then the response status code should be 200
+    Then the response header "Content-Type" should be "application/json"
+    Then the response body should match JSON:
+      """
+      {
+        "version": "",
+        "architecture": "",
+        "modules": null,
+        "modules_additional_data": null,
+        "flags": null
+      }
+      """
+
   Scenario: GET /debug (Gotenberg Trace)
     Given I have a Gotenberg container with the following environment variable(s):
       | API_ENABLE_DEBUG_ROUTE | true |

--- a/test/integration/features/debug.feature
+++ b/test/integration/features/debug.feature
@@ -5,6 +5,23 @@ Feature: /debug
     When I make a "GET" request to Gotenberg at the "/debug" endpoint
     Then the response status code should be 404
 
+  Scenario: GET /debug (Build Debug Data Disabled)
+    Given I have a Gotenberg container with the following environment variable(s):
+      | GOTENBERG_BUILD_DEBUG_DATA | false |
+    When I make a "GET" request to Gotenberg at the "/debug" endpoint
+    Then the response status code should be 200
+    Then the response header "Content-Type" should be "application/json"
+    Then the response body should match JSON:
+      """
+      {
+        "version": "",
+        "architecture": "",
+        "modules": null,
+        "modules_additional_data": null,
+        "flags": null
+      }
+      """
+
   Scenario: GET /debug (Enabled)
     Given I have a Gotenberg container with the following environment variable(s):
       | API_ENABLE_DEBUG_ROUTE | true |
@@ -118,23 +135,6 @@ Feature: /debug
           "webhook-retry-max-wait": "30s",
           "webhook-retry-min-wait": "1s"
         }
-      }
-      """
-
-  Scenario: GET /debug (Build Debug Data Disabled)
-    Given I have a Gotenberg container with the following environment variable(s):
-      | GOTENBERG_BUILD_DEBUG_DATA | false |
-    When I make a "GET" request to Gotenberg at the "/debug" endpoint
-    Then the response status code should be 200
-    Then the response header "Content-Type" should be "application/json"
-    Then the response body should match JSON:
-      """
-      {
-        "version": "",
-        "architecture": "",
-        "modules": null,
-        "modules_additional_data": null,
-        "flags": null
       }
       """
 

--- a/test/integration/features/debug.feature
+++ b/test/integration/features/debug.feature
@@ -86,6 +86,7 @@ Feature: /debug
           "chromium-proxy-server": "",
           "chromium-restart-after": "10",
           "chromium-start-timeout": "20s",
+          "gotenberg-build-debug-data": "true",
           "gotenberg-graceful-shutdown-duration": "30s",
           "libreoffice-auto-start": "false",
           "libreoffice-disable-routes": "false",


### PR DESCRIPTION
The `BuildDebug` function currently accounts for approximately one-third of the CPU time in the `Run()` function at the start of the Gotenberg service.

By building debug information only when the log level is debug, we can cut cold start times by up to 6-10% for all other cases.
I’ve attached profiling flame graphs that show a reduction in startup time from 3ms to 2ms.

While this 1ms improvement may seem minor, in serverless environments like Cloud Run this could represent 1-3s shaved from the 5-10s startup time required by a typical setup of 1 vCPU/1GB memory. 

With BuildDebug:
<img width="2455" alt="Screenshot 2025-04-07 at 2 06 24 PM" src="https://github.com/user-attachments/assets/fe396bba-c0bb-4181-9720-04083dc7478a" />

Without BuilDebug:
<img width="2484" alt="Screenshot 2025-04-07 at 2 06 01 PM" src="https://github.com/user-attachments/assets/665512ac-73d8-4274-aa3d-4abd54388bd0" />