### PR TITLE
add dependabot for mod and docker files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gomod" 
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/build"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I've added the mod and docker files to dependabot so they are kept to date automatically. 

Initially there is no effect in the Docker files, but this will allow to pin specific versions of all dependencies and update them automatically, hence having more deterministic builds. 