### PR TITLE
add docker build arg to pin chromium/chrome version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -111,6 +111,8 @@ FROM base-image-stage
 ARG GOTENBERG_VERSION=snapshot
 ARG GOTENBERG_USER_GID=1001
 ARG GOTENBERG_USER_UID=1001
+ARG CHROME_VERSION
+ARG CHROMIUM_VERSION
 # See https://github.com/googlefonts/noto-emoji/releases.
 ARG NOTO_COLOR_EMOJI_VERSION=v2.047
 # See https://gitlab.com/pdftk-java/pdftk/-/releases - Binary package.
@@ -206,12 +208,12 @@ RUN \
     echo "deb http://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list &&\
     apt-get update -qq &&\
     apt-get upgrade -yqq &&\
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends --allow-unauthenticated google-chrome-stable=${CHROME_VERSION} &&\
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends --allow-unauthenticated google-chrome-stable='${CHROME_VERSION}' &&\
     mv /usr/bin/google-chrome-stable /usr/bin/chromium; \
     else \
     apt-get update -qq &&\
     apt-get upgrade -yqq &&\
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends chromium=${CHROMIUM_VERSION}; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends chromium='${CHROMIUM_VERSION}'; \
     fi' &&\
     # Verify installation.
     chromium --version &&\

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -206,12 +206,12 @@ RUN \
     echo "deb http://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list &&\
     apt-get update -qq &&\
     apt-get upgrade -yqq &&\
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends --allow-unauthenticated google-chrome-stable=$CHROME_VERSION &&\
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends --allow-unauthenticated google-chrome-stable=${CHROME_VERSION} &&\
     mv /usr/bin/google-chrome-stable /usr/bin/chromium; \
     else \
     apt-get update -qq &&\
     apt-get upgrade -yqq &&\
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends chromium=$CHROMIUM_VERSION; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends chromium=${CHROMIUM_VERSION}; \
     fi' &&\
     # Verify installation.
     chromium --version &&\

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,6 +2,7 @@
 # concatenate them. Also, we have to repeat ARG instructions in each build
 # stage that uses them.
 ARG GOLANG_VERSION=1.24
+ARG CHROMIUM_VERSION=137.0.7151.68
 
 # ----------------------------------------------
 # pdfcpu binary build stage
@@ -209,7 +210,7 @@ RUN \
     else \
     apt-get update -qq &&\
     apt-get upgrade -yqq &&\
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends chromium; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends chromium=$CHROMIUM_VERSION; \
     fi' &&\
     # Verify installation.
     chromium --version &&\

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,8 @@
 # concatenate them. Also, we have to repeat ARG instructions in each build
 # stage that uses them.
 ARG GOLANG_VERSION=1.24
-ARG CHROMIUM_VERSION=137.0.7151.68
+ARG CHROME_VERSION=137.0.7151.68
+ARG CHROMIUM_VERSION=135.0.7049.95-1~deb12u1
 
 # ----------------------------------------------
 # pdfcpu binary build stage
@@ -205,7 +206,7 @@ RUN \
     echo "deb http://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list &&\
     apt-get update -qq &&\
     apt-get upgrade -yqq &&\
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends --allow-unauthenticated google-chrome-stable &&\
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends --allow-unauthenticated google-chrome-stable=$CHROME_VERSION &&\
     mv /usr/bin/google-chrome-stable /usr/bin/chromium; \
     else \
     apt-get update -qq &&\


### PR DESCRIPTION
Closes https://github.com/gotenberg/gotenberg/issues/1230 

This isn't really necessary since building against the latest chromium will fix issue #1230, however I thought it would be a neat bonus to be able to control the chromium version as a build arg. This is so that someone can control the version of chromium against a version of gotenberg

Feel free to disregard!