### PR TITLE
Use same targeted platform integration-tools image @ integration tests

### DIFF
--- a/test/integration/scenario/containers.go
+++ b/test/integration/scenario/containers.go
@@ -69,7 +69,7 @@ func execCommandInIntegrationToolsContainer(ctx context.Context, cmd []string, p
 	defer cancel()
 
 	req := testcontainers.ContainerRequest{
-		Image: "gotenberg/integration-tools:latest",
+		Image:         "gotenberg/integration-tools:latest",
 		ImagePlatform: GotenbergContainerPlatform,
 		Files: []testcontainers.ContainerFile{
 			{

--- a/test/integration/scenario/containers.go
+++ b/test/integration/scenario/containers.go
@@ -70,6 +70,7 @@ func execCommandInIntegrationToolsContainer(ctx context.Context, cmd []string, p
 
 	req := testcontainers.ContainerRequest{
 		Image: "gotenberg/integration-tools:latest",
+		ImagePlatform: GotenbergContainerPlatform,
 		Files: []testcontainers.ContainerFile{
 			{
 				HostFilePath:      path,


### PR DESCRIPTION
Spin via testcontainers an integration-tools image with the same targeted platform.

@gulien I am struggling with formatting and linting 😢 
` make lint
golangci-lint run
level=error msg="[linters_context] typechecking error: : # github.com/gotenberg/gotenberg/v8/pkg/gotenberg\npkg\\gotenberg\\cmd.go:30:41: unknown field Setpgid in struct literal of type syscall.SysProcAttr\npkg\\gotenberg\\cmd.go:50:41: unknown field Setpgid in struct literal of type syscall.SysProcAttr\npkg\\gotenberg\\cmd.go:197:17: undefined: syscall.Kill"
0 issues.
make: *** [Makefile:168: lint] Error 7`

Any suggestions?

May you fix and finalize this PR, please?