### PR TITLE
fix(chromium): Enable GPU support

### DIFF
--- a/pkg/modules/chromium/browser.go
+++ b/pkg/modules/chromium/browser.go
@@ -84,10 +84,6 @@ func (b *chromiumBrowser) Start(logger *zap.Logger) error {
 		chromedp.ExecPath(b.arguments.binPath),
 		chromedp.NoSandbox,
 		// See:
-		// https://github.com/gotenberg/gotenberg/issues/327
-		// https://github.com/chromedp/chromedp/issues/904
-		chromedp.DisableGPU,
-		// See:
 		// https://github.com/puppeteer/puppeteer/issues/661
 		// https://github.com/puppeteer/puppeteer/issues/2410
 		chromedp.Flag("font-render-hinting", "none"),


### PR DESCRIPTION
Chromium 139 is set to deprecate the Swiftshader backend entirely:

https://chromestatus.com/feature/5166674414927872

And 138 doesn't provide fallback without explicitly enabling it, breaking functionality such as WebGL in Gotenberg

Re-enable GPU support to work around this