### PR TITLE
feat(Dockerfile): add basic LibreOffice Hyphenation support

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -177,7 +177,7 @@ RUN \
 
 RUN \
     # Install Hyphenation for LibreOffice.
-    # Credits: https://wiki.archlinux.org/title/LibreOffice
+    # Credits: https://wiki.archlinux.org/title/LibreOffice.
     apt-get update -qq &&\
     apt-get upgrade -yqq &&\
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \


### PR DESCRIPTION
One of our coworkers gave us the heads up that Gotenberg did not have Hyphenation support out of the box for LibreOffice conversions, so words are forced to be moved around to fit entirely in their line.
Upon investigation (and a quick tip from the [ArchLinux wiki](https://wiki.archlinux.org/title/LibreOffice)), they were able to find the [`hyphen-*` set of packages on Debian](https://packages.debian.org/search?suite=trixie&keywords=hyphen-), which add basic support for it on the supported languages.

It is clear by reading some other references (see [Gotenberg's own Switch Language](https://gotenberg.dev/docs/configuration#switch-language) docs, and [Debian Wiki's LibreOffice](https://wiki.debian.org/LibreOffice#Extending_functionalities) entry), that the _"real"_ way to add Hyphenation is through **Language** / **Dictionary** support (ie. `hunspell-*` / `myspell-*` packages), but this small addition has proven to be good enough for _just_ hyphenation without exploding the size of the container (only ~30MB increase).

This PR then adds those language hyphen packages into the Dockerfile so they are available in the final stage.
Just to clarify: I tried to style it as close as possible to the other blocks -- there's no particular need for them to be "isolated", or anything like that, do with that what you will.

[Here's a file you can quickly test with in English](https://github.com/user-attachments/files/22784367/hyphen-en.docx), if needed -- else just make a DOCX file with big margins so the text is "squished" into hyphenation 🙂 