### PR TITLE
feat: add tests tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,12 +162,13 @@ PLATFORM=
 NO_CONCURRENCY=false
 
 .PHONY: test-integration
-test-integration: ## Run integration tests
+test-integration: ## Run integration tests, use TAGS environment variable to filter tests by tags
 	go test -timeout 40m -tags=integration -v github.com/gotenberg/gotenberg/v8/test/integration -args \
 	--gotenberg-docker-repository=$(DOCKER_REPOSITORY) \
 	--gotenberg-version=$(GOTENBERG_VERSION) \
  	--gotenberg-container-platform=$(PLATFORM) \
- 	--no-concurrency=$(NO_CONCURRENCY)
+ 	--no-concurrency=$(NO_CONCURRENCY) \
+ 	--tags="$(TAGS)"
 
 .PHONY: lint
 lint: ## Lint Golang codebase

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -19,6 +19,7 @@ func TestMain(m *testing.M) {
 	version := flag.String("gotenberg-version", "", "")
 	platform := flag.String("gotenberg-container-platform", "", "")
 	noConcurrency := flag.Bool("no-concurrency", false, "")
+	tags := flag.String("tags", "", "")
 	flag.Parse()
 
 	if *platform == "" {
@@ -47,6 +48,7 @@ func TestMain(m *testing.M) {
 			Paths:       []string{"features"},
 			Output:      colors.Colored(os.Stdout),
 			Concurrency: concurrency,
+			Tags:        *tags,
 		},
 	}.Run()
 


### PR DESCRIPTION
# Description

This PR add a way to run tests matching a given tag.

# Usage

```console
# Run all tests (unchanged behavior)
make test-integration

# Run tests tagged with @wip
make test-integration TAGS=@wip

# Run tests related to a specific feature (ex: feature added in https://github.com/gotenberg/gotenberg/pull/1373)
make test-integration TAGS=@embed
```