### PR TITLE
chore(deps): bump Go from 1.25.0 to 1.25.4

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # ARG instructions do not create additional layers. Instead, next layers will
 # concatenate them. Also, we have to repeat ARG instructions in each build
 # stage that uses them.
-ARG GOLANG_VERSION=1.25.0
+ARG GOLANG_VERSION=1.25.4
 
 # ----------------------------------------------
 # pdfcpu binary build stage

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gotenberg/gotenberg/v8
 
-go 1.25.0
+go 1.25.4
 
 require (
 	github.com/alexliesenfeld/health v0.8.1


### PR DESCRIPTION
- go1.25.1 (released 2025-09-03) includes security fixes to the net/http package, as well as bug fixes to the go command, and the net, os, os/exec, and testing/synctest packages.
- go1.25.2 (released 2025-10-07) includes security fixes to the archive/tar, crypto/tls, crypto/x509, encoding/asn1, encoding/pem, net/http, net/mail, net/textproto, and net/url packages, as well as bug fixes to the compiler, the runtime, and the context, debug/pe, net/http, os, and sync/atomic packages.
- go1.25.3 (released 2025-10-13) includes fixes to the crypto/x509 package.
- go1.25.4 (released 2025-11-05) includes fixes to the compiler, the runtime, and the crypto/subtle, encoding/pem, net/url, and os packages.