### PR TITLE
Handle `net::ERR_HTTP2_PROTOCOL_ERROR`

### DIFF
--- a/pkg/modules/chromium/events.go
+++ b/pkg/modules/chromium/events.go
@@ -235,7 +235,7 @@ func listenForEventLoadingFailed(ctx context.Context, logger *zap.Logger, option
 				"net::ERR_BLOCKED_BY_CLIENT",
 				"net::ERR_BLOCKED_BY_RESPONSE",
 				"net::ERR_FILE_NOT_FOUND",
-				"net::ERR_HTTP2_PROTOCOL_ERROR"
+				"net::ERR_HTTP2_PROTOCOL_ERROR",
 			}
 			if !slices.Contains(errors, ev.ErrorText) {
 				logger.Debug(fmt.Sprintf("skip EventLoadingFailed: '%s' is not part of %+v", ev.ErrorText, errors))


### PR DESCRIPTION
Adds `net::ERR_HTTP2_PROTOCOL_ERROR` to list of expected EventLoadingFailed errors. 

We use services in a docker container, and the inability to handle this error seems to be causing requests to hang. 
Debug logs from the service:
```
event EventRequestPaused fired for <url>
event EventLoadingFailed fired: net::ERR_HTTP2_PROTOCOL_ERROR
skip EventLoadingFailed: 'net::ERR_HTTP2_PROTOCOL_ERROR' is not part of [net::ERR_CONNECTION_CLOSED net::ERR_CONNECTION_RESET net::ERR_CONNECTION_REFUSED net::ERR_CONNECTION_ABORTED net::ERR_CONNECTION_FAILED net::ERR_NAME_NOT_RESOLVED net::ERR_INTERNET_DISCONNECTED net::ERR_ADDRESS_UNREACHABLE net::ERR_BLOCKED_BY_CLIENT net::ERR_BLOCKED_BY_RESPONSE net::ERR_FILE_NOT_FOUND]
```

Please let me know if I need to add anything else (tests, handlers, etc.)