### PR TITLE
feat: Allow configuration of Prometheus metrics endpoint path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ PROMETHEUS_NAMESPACE=gotenberg
 PROMETHEUS_COLLECT_INTERVAL=1s
 PROMETHEUS_DISABLE_ROUTE_LOGGING=false
 PROMETHEUS_DISABLE_COLLECT=false
+PROMETHEUS_METRICS_PATH=/prometheus/metrics
 WEBHOOK_ENABLE_SYNC_MODE=false
 WEBHOOK_ALLOW_LIST=
 WEBHOOK_DENY_LIST=
@@ -143,6 +144,7 @@ run: ## Start a Gotenberg container
 	--prometheus-collect-interval=$(PROMETHEUS_COLLECT_INTERVAL) \
 	--prometheus-disable-route-logging=$(PROMETHEUS_DISABLE_ROUTE_LOGGING) \
 	--prometheus-disable-collect=$(PROMETHEUS_DISABLE_COLLECT) \
+	--prometheus-metrics-path=$(PROMETHEUS_METRICS_PATH) \
 	--webhook-enable-sync-mode="$(WEBHOOK_ENABLE_SYNC_MODE)" \
 	--webhook-allow-list="$(WEBHOOK_ALLOW_LIST)" \
 	--webhook-deny-list="$(WEBHOOK_DENY_LIST)" \

--- a/test/integration/features/debug.feature
+++ b/test/integration/features/debug.feature
@@ -109,6 +109,7 @@ Feature: /debug
           "prometheus-disable-collect": "false",
           "prometheus-disable-route-logging": "false",
           "prometheus-namespace": "gotenberg",
+          "prometheus-metrics-path": "/prometheus/metrics",
           "webhook-allow-list": "",
           "webhook-client-timeout": "30s",
           "webhook-deny-list": "",

--- a/test/integration/features/prometheus_metrics.feature
+++ b/test/integration/features/prometheus_metrics.feature
@@ -29,6 +29,31 @@ Feature: /prometheus/metrics
     Then the Gotenberg container should log the following entries:
       | "path":"/prometheus/metrics" |
 
+  Scenario: GET /custom/metrics (Custom Metrics Path)
+    Given I have a Gotenberg container with the following environment variable(s):
+      | PROMETHEUS_METRICS_PATH | /custom/metrics |
+    When I make a "GET" request to Gotenberg at the "/custom/metrics" endpoint
+    Then the response status code should be 200
+    Then the response header "Content-Type" should be "text/plain; version=0.0.4; charset=utf-8; escaping=underscores"
+    Then the response body should match string:
+      """
+      # HELP gotenberg_chromium_requests_queue_size Current number of Chromium conversion requests waiting to be treated.
+      # TYPE gotenberg_chromium_requests_queue_size gauge
+      gotenberg_chromium_requests_queue_size 0
+      # HELP gotenberg_chromium_restarts_count Current number of Chromium restarts.
+      # TYPE gotenberg_chromium_restarts_count gauge
+      gotenberg_chromium_restarts_count 0
+      # HELP gotenberg_libreoffice_requests_queue_size Current number of LibreOffice conversion requests waiting to be treated.
+      # TYPE gotenberg_libreoffice_requests_queue_size gauge
+      gotenberg_libreoffice_requests_queue_size 0
+      # HELP gotenberg_libreoffice_restarts_count Current number of LibreOffice restarts.
+      # TYPE gotenberg_libreoffice_restarts_count gauge
+      gotenberg_libreoffice_restarts_count 0
+
+      """
+    Then the Gotenberg container should log the following entries:
+      | "path":"/custom/metrics" |
+
   Scenario: GET /prometheus/metrics (Custom Namespace)
     Given I have a Gotenberg container with the following environment variable(s):
       | PROMETHEUS_NAMESPACE | foo |


### PR DESCRIPTION
## Description

This PR fixes #1407 and allows to config prometheus metrics endpoint path

## Changes

Adds a new environment/flag variable that can be used to specify a custom prometheus metrics endpoint path

### Environment

`PROMETHEUS_METRICS_PATH=/custom/metics/path`

### Flag

`--prometheus-metrics-path=/custom/metics/path`

### todo

- [x] update documentation (gotenberg/gotenberg.dev#38)