### PR TITLE
chore(go): Update Go to 1.25.5

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # ARG instructions do not create additional layers. Instead, next layers will
 # concatenate them. Also, we have to repeat ARG instructions in each build
 # stage that uses them.
-ARG GOLANG_VERSION=1.25.4
+ARG GOLANG_VERSION=1.25.5
 
 # ----------------------------------------------
 # pdfcpu binary build stage


### PR DESCRIPTION
This updates the Go version to 1.25.5, which resolves CVE-2025-61729 in the stdlib.