### PR TITLE
chore(go): bump Go to 1.25.7

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # ARG instructions do not create additional layers. Instead, next layers will
 # concatenate them. Also, we have to repeat ARG instructions in each build
 # stage that uses them.
-ARG GOLANG_VERSION=1.25.5
+ARG GOLANG_VERSION=1.25.7
 
 # ----------------------------------------------
 # pdfcpu binary build stage

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gotenberg/gotenberg/v8
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/alexliesenfeld/health v0.8.1


### PR DESCRIPTION
- go1.25.6 (released 2026-01-15) includes security fixes to the go command, and the archive/zip, crypto/tls, and net/url packages, as well as bug fixes to the compiler, the runtime, and the crypto/tls, errors, and os packages.

- go1.25.7 (released 2026-02-04) includes security fixes to the go command and the crypto/tls package, as well as bug fixes to the compiler and the crypto/x509 package.