### PR TITLE
fix(supervisor): retry failed first start instead of caching the error (#1538)

### DIFF
--- a/pkg/gotenberg/supervisor.go
+++ b/pkg/gotenberg/supervisor.go
@@ -85,13 +85,14 @@ type processSupervisor struct {
 	maxQueueSize   int64
 	maxConcurrency int64
 	semaphore      chan struct{}
-	firstStart     atomic.Bool
-	firstStartOnce sync.Once
-	// firstStartErr stores the error from the first Launch attempt executed
-	// via firstStartOnce. Subsequent callers that enter the !firstStart block
-	// need to observe this value after the Once has completed, without
-	// re-executing the closure.
-	firstStartErr       error
+	firstStart atomic.Bool
+	// firstStartMu serialises Launch attempts in ensureStarted. It is held
+	// only across a single Launch call; a successful Launch flips
+	// firstStart=true so subsequent callers short-circuit before taking the
+	// lock. A *failed* Launch leaves firstStart=false so the next request
+	// gets a fresh attempt — the supervisor must not cache a transient
+	// startup error for the lifetime of the container (issue #1538).
+	firstStartMu        sync.Mutex
 	reqCounter          atomic.Int64
 	reqQueueSize        atomic.Int64
 	restartsCounter     atomic.Int64
@@ -346,8 +347,6 @@ func (s *processSupervisor) maybeIdleShutdown() {
 
 	// Reset state so ensureStarted() re-launches on next request.
 	s.firstStart.Store(false)
-	s.firstStartOnce = sync.Once{}
-	s.firstStartErr = nil
 	s.reqCounter.Store(0)
 
 	s.logger.DebugContext(context.Background(), "process stopped due to idle timeout")
@@ -375,21 +374,34 @@ func (s *processSupervisor) acquireSlot(ctx context.Context, logger *slog.Logger
 	}
 }
 
-// ensureStarted performs a one-time lazy launch of the process on its first
-// use. Subsequent calls are no-ops.
+// ensureStarted lazily launches the process on first use. A successful
+// Launch flips firstStart=true so subsequent callers short-circuit; a
+// *failed* Launch leaves firstStart=false so the next caller retries.
+//
+// Earlier versions used sync.Once + a cached firstStartErr, which meant
+// any first-attempt error (e.g. an aggressive --libreoffice-start-timeout)
+// was returned to every subsequent request for the lifetime of the
+// container until it was restarted (issue #1538). The mutex below
+// serialises concurrent first-launch attempts so we still only run one
+// Launch at a time, without caching the failure.
 func (s *processSupervisor) ensureStarted(ctx context.Context) error {
 	if s.firstStart.Load() {
 		return nil
 	}
 
-	s.firstStartOnce.Do(func() {
-		s.firstStartErr = s.runWithDeadline(ctx, func() error {
-			return s.Launch()
-		})
-	})
+	s.firstStartMu.Lock()
+	defer s.firstStartMu.Unlock()
 
-	if s.firstStartErr != nil {
-		return fmt.Errorf("process first start: %w", s.firstStartErr)
+	// Re-check after acquiring the lock: another goroutine may have
+	// completed a successful Launch while we were waiting.
+	if s.firstStart.Load() {
+		return nil
+	}
+
+	if err := s.runWithDeadline(ctx, func() error {
+		return s.Launch()
+	}); err != nil {
+		return fmt.Errorf("process first start: %w", err)
 	}
 
 	return nil

--- a/pkg/gotenberg/supervisor_test.go
+++ b/pkg/gotenberg/supervisor_test.go
@@ -941,3 +941,85 @@ func TestProcessSupervisor_IdleShutdownSkippedWhenActive(t *testing.T) {
 
 	close(taskDone)
 }
+
+// TestProcessSupervisor_FirstStart_RetriesAfterFailure pins the fix for
+// issue #1538: if Launch fails on the first request (e.g. an aggressive
+// --libreoffice-start-timeout), the supervisor must let the *next*
+// request retry the launch instead of replaying the cached error to
+// every subsequent caller until the container is restarted.
+func TestProcessSupervisor_FirstStart_RetriesAfterFailure(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	var startCalls atomic.Int32
+	process := &ProcessMock{
+		StartMock: func(logger *slog.Logger) error {
+			n := startCalls.Add(1)
+			if n == 1 {
+				return errors.New("first start: timeout")
+			}
+			return nil
+		},
+		HealthyMock: func(logger *slog.Logger) bool { return true },
+	}
+
+	ps := NewProcessSupervisor(logger, process, 0, 0, 1, 0).(*processSupervisor)
+
+	// First request: Launch fails, Run returns the error, firstStart
+	// must remain false so the cached failure does not persist.
+	if err := ps.ensureStarted(context.Background()); err == nil {
+		t.Fatal("first ensureStarted: expected error from failed launch, got nil")
+	}
+	if ps.firstStart.Load() {
+		t.Fatal("firstStart must remain false after a failed Launch")
+	}
+
+	// Second request: Launch succeeds, ensureStarted returns nil and
+	// firstStart flips to true. Without the fix, this call would have
+	// replayed the cached firstStartErr from the prior sync.Once.
+	if err := ps.ensureStarted(context.Background()); err != nil {
+		t.Fatalf("second ensureStarted (succeeding launch): unexpected error: %v", err)
+	}
+	if !ps.firstStart.Load() {
+		t.Fatal("firstStart must be true after a successful Launch")
+	}
+	if got := startCalls.Load(); got != 2 {
+		t.Fatalf("Start mock invocations = %d, want 2 (one failed, one retried)", got)
+	}
+
+	// Third request: short-circuit — no further Start calls.
+	if err := ps.ensureStarted(context.Background()); err != nil {
+		t.Fatalf("third ensureStarted (already started): unexpected error: %v", err)
+	}
+	if got := startCalls.Load(); got != 2 {
+		t.Fatalf("Start mock invocations after already-started = %d, want 2", got)
+	}
+}
+
+// TestProcessSupervisor_FirstStart_NoRetryAfterSuccess pins the
+// "happy path stays cached" half of the contract — once Launch has
+// succeeded, ensureStarted is a pure no-op for every subsequent
+// caller. Combined with the retry test above, this proves the cache
+// is keyed on success rather than on "Launch was attempted at all"
+// (the #1538 regression).
+func TestProcessSupervisor_FirstStart_NoRetryAfterSuccess(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	var startCalls atomic.Int32
+	process := &ProcessMock{
+		StartMock: func(logger *slog.Logger) error {
+			startCalls.Add(1)
+			return nil
+		},
+	}
+
+	ps := NewProcessSupervisor(logger, process, 0, 0, 1, 0).(*processSupervisor)
+
+	for i := 0; i < 5; i++ {
+		if err := ps.ensureStarted(context.Background()); err != nil {
+			t.Fatalf("ensureStarted #%d: %v", i, err)
+		}
+	}
+	if got := startCalls.Load(); got != 1 {
+		t.Fatalf("Start invocations = %d, want 1 (cached after success)", got)
+	}
+}


### PR DESCRIPTION
Closes #1538.

## What

`processSupervisor.ensureStarted` used `sync.Once` plus a cached
`firstStartErr` to make sure `Launch` ran exactly once on the first
request. The side effect was that any *failed* first-start attempt —
e.g. an aggressive `--libreoffice-start-timeout` exceeding the host's
actual cold-start duration — was permanently cached and replayed to
every subsequent request for the lifetime of the container.

Reproduction (from the issue):

1. Run with `--libreoffice-start-timeout=1s`.
2. First request fails with `process first start: ... context deadline
   exceeded`.
3. Every later request fails immediately with the same error until the
   container restarts.

## Why this regressed in 8.27.0

#1467 reworked the supervisor for concurrency and introduced
`firstStartOnce` / `firstStartErr`. `sync.Once` doesn't distinguish
"never ran" from "ran and failed", so once the closure executed it
never re-ran.

## Fix

Replace `sync.Once` / `firstStartErr` with `firstStartMu`
(`sync.Mutex`). New `ensureStarted`:

- short-circuits on `firstStart.Load()` (hot path unchanged),
- takes `firstStartMu` and re-checks `firstStart` inside the lock,
- runs `Launch` under the lock; on success `Launch` flips
  `firstStart=true`, so future callers skip the lock entirely,
- on failure, `firstStart` stays `false` so the *next* request gets a
  fresh attempt rather than the cached error.

`maybeIdleShutdown` simplifies — only `firstStart` needs clearing;
the `firstStartOnce` / `firstStartErr` lines go away.

## Tests

- `TestProcessSupervisor_FirstStart_RetriesAfterFailure` — first call
  errors and `firstStart` stays `false`; second call (succeeding
  Launch) returns `nil` and `firstStart` flips `true`; third call
  short-circuits without a third Start invocation.
- `TestProcessSupervisor_FirstStart_NoRetryAfterSuccess` — 5 sequential
  calls after a successful Launch produce exactly one Start
  invocation.

## Verification

- `go build ./pkg/gotenberg/...` ✅
- `go vet ./pkg/gotenberg/...` ✅
- `go test -race -count=1 ./pkg/gotenberg/...` ✅ — full package green
  under the race detector.