### PR TITLE
feat(chromium): allow to specify device scale ratio for screenshots

### DIFF
--- a/.bruno/Chromium/Screenshot/HTML Screenshot.bru
+++ b/.bruno/Chromium/Screenshot/HTML Screenshot.bru
@@ -34,6 +34,7 @@ body:multipart-form {
   ~emulatedMediaType: screen
   ~emulatedMediaFeatures: {"prefers-color-scheme":"dark"}
   ~omitBackground: false
+  ~deviceScaleFactor: 1.0
 }
 
 headers {

--- a/.bruno/Chromium/Screenshot/Markdown Screenshot.bru
+++ b/.bruno/Chromium/Screenshot/Markdown Screenshot.bru
@@ -35,6 +35,7 @@ body:multipart-form {
   ~emulatedMediaType: screen
   ~emulatedMediaFeatures: {"prefers-color-scheme":"dark"}
   ~omitBackground: false
+  ~deviceScaleFactor: 1.0
 }
 
 headers {

--- a/.bruno/Chromium/Screenshot/URL Screenshot.bru
+++ b/.bruno/Chromium/Screenshot/URL Screenshot.bru
@@ -34,6 +34,7 @@ body:multipart-form {
   ~emulatedMediaType: screen
   ~emulatedMediaFeatures: {"prefers-color-scheme":"dark"}
   ~omitBackground: false
+  ~deviceScaleFactor: 1.0
 }
 
 headers {

--- a/pkg/modules/chromium/browser.go
+++ b/pkg/modules/chromium/browser.go
@@ -351,7 +351,7 @@ func (b *chromiumBrowser) screenshot(ctx context.Context, logger *slog.Logger, u
 		waitForSelectorVisibleBeforePrintActionFunc(logger, options.WaitForSelector),
 		waitDelayBeforePrintActionFunc(logger, b.arguments.disableJavaScript, options.WaitDelay),
 		// Screenshot specific.
-		setDeviceMetricsOverride(logger, options.Width, options.Height),
+		setDeviceMetricsOverride(logger, options.Width, options.Height, options.DeviceScaleFactor),
 		captureScreenshotActionFunc(logger, outputPath, options),
 		// Teardown.
 		page.Close(),

--- a/pkg/modules/chromium/chromium.go
+++ b/pkg/modules/chromium/chromium.go
@@ -350,18 +350,23 @@ type ScreenshotOptions struct {
 	// OptimizeForSpeed defines whether to optimize image encoding for speed,
 	// not for resulting size.
 	OptimizeForSpeed bool
+
+	// DeviceScaleFactor is the ratio of the resolution in physical pixels to
+	// the resolution in CSS pixels for the current display device.
+	DeviceScaleFactor float64
 }
 
 // DefaultScreenshotOptions returns the default values for ScreenshotOptions.
 func DefaultScreenshotOptions() ScreenshotOptions {
 	return ScreenshotOptions{
-		Options:          DefaultOptions(),
-		Width:            800,
-		Height:           600,
-		Clip:             false,
-		Format:           "png",
-		Quality:          100,
-		OptimizeForSpeed: false,
+		Options:           DefaultOptions(),
+		Width:             800,
+		Height:            600,
+		Clip:              false,
+		Format:            "png",
+		Quality:           100,
+		OptimizeForSpeed:  false,
+		DeviceScaleFactor: 1.0,
 	}
 }
 

--- a/pkg/modules/chromium/routes.go
+++ b/pkg/modules/chromium/routes.go
@@ -341,11 +341,12 @@ func FormDataChromiumScreenshotOptions(ctx *api.Context) (*api.FormData, Screens
 	defaultScreenshotOptions := DefaultScreenshotOptions()
 
 	var (
-		width, height    int
-		clip             bool
-		format           string
-		quality          int
-		optimizeForSpeed bool
+		width, height     int
+		clip              bool
+		format            string
+		quality           int
+		optimizeForSpeed  bool
+		deviceScaleFactor float64
 	)
 
 	form.
@@ -388,16 +389,18 @@ func FormDataChromiumScreenshotOptions(ctx *api.Context) (*api.FormData, Screens
 			quality = intValue
 			return nil
 		}).
-		Bool("optimizeForSpeed", &optimizeForSpeed, defaultScreenshotOptions.OptimizeForSpeed)
+		Bool("optimizeForSpeed", &optimizeForSpeed, defaultScreenshotOptions.OptimizeForSpeed).
+		Float64("deviceScaleFactor", &deviceScaleFactor, defaultScreenshotOptions.DeviceScaleFactor)
 
 	screenshotOptions := ScreenshotOptions{
-		Options:          options,
-		Width:            width,
-		Height:           height,
-		Clip:             clip,
-		Format:           format,
-		Quality:          quality,
-		OptimizeForSpeed: optimizeForSpeed,
+		Options:           options,
+		Width:             width,
+		Height:            height,
+		Clip:              clip,
+		Format:            format,
+		Quality:           quality,
+		OptimizeForSpeed:  optimizeForSpeed,
+		DeviceScaleFactor: deviceScaleFactor,
 	}
 
 	return form, screenshotOptions

--- a/pkg/modules/chromium/tasks.go
+++ b/pkg/modules/chromium/tasks.go
@@ -164,11 +164,11 @@ func captureScreenshotActionFunc(logger *slog.Logger, outputPath string, options
 	}
 }
 
-func setDeviceMetricsOverride(logger *slog.Logger, width, height int) chromedp.ActionFunc {
+func setDeviceMetricsOverride(logger *slog.Logger, width, height int, deviceScaleFactor float64) chromedp.ActionFunc {
 	return func(ctx context.Context) error {
 		logger.DebugContext(ctx, "set device metrics override")
 
-		err := emulation.SetDeviceMetricsOverride(int64(width), int64(height), 1.0, false).Do(ctx)
+		err := emulation.SetDeviceMetricsOverride(int64(width), int64(height), deviceScaleFactor, false).Do(ctx)
 		if err == nil {
 			return nil
 		}

--- a/test/integration/features/chromium_screenshot_html.feature
+++ b/test/integration/features/chromium_screenshot_html.feature
@@ -72,6 +72,15 @@ Feature: /forms/chromium/screenshot/html
     Then the response status code should be 200
     Then the response header "Content-Type" should be "image/png"
 
+  Scenario: POST /forms/chromium/screenshot/html (Device Scale Factor)
+    Given I have a default Gotenberg container
+    When I make a "POST" request to Gotenberg at the "/forms/chromium/screenshot/html" endpoint with the following form data and header(s):
+      | files                     | testdata/page-1-html/index.html | file   |
+      | deviceScaleFactor         | 1.0                             | field  |
+      | Gotenberg-Output-Filename | foo                             | header |
+    Then the response status code should be 200
+    Then the response header "Content-Type" should be "image/png"
+
   Scenario: POST /forms/chromium/screenshot/html (Omit Background)
     Given I have a default Gotenberg container
     When I make a "POST" request to Gotenberg at the "/forms/chromium/screenshot/html" endpoint with the following form data and header(s):


### PR DESCRIPTION
### Summary
Adds a new `deviceScaleFactor` form field to Chromium with backwards-compatible defaults.

### Why
I had a need to generate hi-resolution images for sharing on social media, was not able to achieve this with currently present features.