### PR TITLE
ci: Add GitHub Container Registry (ghcr.io) publishing

### DIFF
--- a/.github/actions/merge/action.yml
+++ b/.github/actions/merge/action.yml
@@ -39,6 +39,14 @@ runs:
         username: ${{ inputs.docker_hub_username }}
         password: ${{ inputs.docker_hub_password }}
 
+    - name: Log in to GitHub Container Registry
+      if: inputs.alternate_registry != ''
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github_token }}
+
     - name: Merge
       shell: bash
       env:

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -152,6 +152,9 @@ jobs:
       - release_arm_v7
     name: Merge and clean release tags
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout source code
         uses: actions/checkout@v6
@@ -161,6 +164,7 @@ jobs:
         with:
           docker_hub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker_hub_password: ${{ secrets.DOCKERHUB_TOKEN }}
+          alternate_registry: ghcr.io/${{ github.repository_owner }}
           tags: "${{ needs.release_amd64.outputs.tags }},${{ needs.release_386.outputs.tags }},${{ needs.release_ppc64le.outputs.tags }},${{ needs.release_arm64.outputs.tags }},${{ needs.release_arm_v7.outputs.tags }}"
 
       - name: Merge Chromium
@@ -168,6 +172,7 @@ jobs:
         with:
           docker_hub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker_hub_password: ${{ secrets.DOCKERHUB_TOKEN }}
+          alternate_registry: ghcr.io/${{ github.repository_owner }}
           tags: "${{ needs.release_amd64.outputs.tags_chromium }},${{ needs.release_386.outputs.tags_chromium }},${{ needs.release_ppc64le.outputs.tags_chromium }},${{ needs.release_arm64.outputs.tags_chromium }},${{ needs.release_arm_v7.outputs.tags_chromium }}"
 
       - name: Merge LibreOffice
@@ -175,6 +180,7 @@ jobs:
         with:
           docker_hub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker_hub_password: ${{ secrets.DOCKERHUB_TOKEN }}
+          alternate_registry: ghcr.io/${{ github.repository_owner }}
           tags: "${{ needs.release_amd64.outputs.tags_libreoffice }},${{ needs.release_386.outputs.tags_libreoffice }},${{ needs.release_ppc64le.outputs.tags_libreoffice }},${{ needs.release_arm64.outputs.tags_libreoffice }},${{ needs.release_arm_v7.outputs.tags_libreoffice }}"
 
       - name: Merge AWS Lambda
@@ -182,6 +188,7 @@ jobs:
         with:
           docker_hub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker_hub_password: ${{ secrets.DOCKERHUB_TOKEN }}
+          alternate_registry: ghcr.io/${{ github.repository_owner }}
           tags: "${{ needs.release_amd64.outputs.tags_aws_lambda }},${{ needs.release_arm64.outputs.tags_aws_lambda }}"
 
       - name: Merge AWS Lambda Chromium
@@ -189,6 +196,7 @@ jobs:
         with:
           docker_hub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker_hub_password: ${{ secrets.DOCKERHUB_TOKEN }}
+          alternate_registry: ghcr.io/${{ github.repository_owner }}
           tags: "${{ needs.release_amd64.outputs.tags_aws_lambda_chromium }},${{ needs.release_arm64.outputs.tags_aws_lambda_chromium }}"
 
       - name: Merge AWS Lambda LibreOffice
@@ -196,6 +204,7 @@ jobs:
         with:
           docker_hub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker_hub_password: ${{ secrets.DOCKERHUB_TOKEN }}
+          alternate_registry: ghcr.io/${{ github.repository_owner }}
           tags: "${{ needs.release_amd64.outputs.tags_aws_lambda_libreoffice }},${{ needs.release_arm64.outputs.tags_aws_lambda_libreoffice }}"
 
       - name: Clean


### PR DESCRIPTION
## Summary
This PR adds GitHub Container Registry (ghcr.io) as an additional publishing target alongside Docker Hub.

## Motivation
Docker Hub's rate limiting (100 pulls/6hrs anonymous, 200 free) increasingly impacts CI/CD and self-hosted infrastructure. ghcr.io provides no rate limits for public images, a unified code+containers ecosystem, needs no extra secrets (uses the existing GITHUB_TOKEN), and reuses the same build — just an additional registry target.

## Changes
This change deliberately reuses the repository's *existing* alternate-registry mechanism rather than adding any new build or tag logic:

- `.github/workflows/continuous-delivery.yml`:
  - Added `permissions: contents: read` + `packages: write` to the `merge_clean_release_tags` job so it can push to ghcr.io.
  - Passed `alternate_registry: ghcr.io/${{ github.repository_owner }}` to each of the existing `Merge` steps (full, Chromium, LibreOffice, AWS Lambda, AWS Lambda Chromium, AWS Lambda LibreOffice). This produces `ghcr.io/${{ github.repository }}` (i.e. `ghcr.io/gotenberg/gotenberg`) tags via the already-present `alternate_registry` path in `.github/actions/merge/merge.sh`.
- `.github/actions/merge/action.yml`:
  - Added a `docker/login-action@v3` step for `ghcr.io` (username `${{ github.actor }}`, password `${{ inputs.github_token }}`) immediately after the existing Docker Hub login. It is guarded by `if: inputs.alternate_registry != ''`, so it only runs when an alternate registry is requested.

No build args, platforms/multi-arch, build context, cache, tag strategy, or existing Docker Hub tags were changed. The ghcr.io manifests are created by re-tagging the already-merged multi-arch Docker Hub manifest via `docker buildx imagetools create`, so they carry the identical set of platforms and the same tag suffixes.

## Backward Compatibility
Fully backward compatible — Docker Hub publishing is unchanged; this only adds an additional registry target.

## Note on Previous Discussion
I saw this was discussed previously and declined due to Docker Sponsored OSS status. I wanted to revisit because: (1) many users run private CI/CD that doesn't benefit from Docker Sponsored OSS exemptions; (2) self-hosted environments (Kubernetes, Docker Swarm) still hit rate limits; (3) ghcr.io adds redundancy if Docker Hub has availability issues. Completely understand if the answer is still no — happy to close if not wanted. (Refs #1136.)

## Testing
- [x] Workflow YAML validated
- [ ] Builds in maintainer CI on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

### 🔧 One-time maintainer step: make the GHCR package public

Heads-up for maintainers: the first time this workflow publishes to `ghcr.io/gotenberg/gotenberg`, GitHub creates the package as **private** by default. To let users `docker pull` it without authentication, a maintainer needs to set its visibility to **Public** once:

> Repo **Packages** → the new `gotenberg` package → **Package settings** → **Danger Zone** → **Change visibility** → **Public**

It's a one-time action — subsequent pushes inherit the setting. (Flagged by an automated reviewer; surfacing it here so the rollout is smooth.)

<!-- ghcr-visibility-note -->