### PR TITLE
fix(Dockerfile): add ca-certificates, missing in chromium-only image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -125,6 +125,7 @@ RUN groupadd --gid "$GOTENBERG_USER_GID" gotenberg \
 RUN apt-get update -qq \
     && apt-get upgrade -yqq \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+        ca-certificates \
         tini \
         # Many users rely on curl for Docker health checks.
         curl \


### PR DESCRIPTION
The gotenberg and gotenberg-libreoffice images pull in ca-certificates as a dependency of python3-distutils-extra, but it's missing from the gotenberg-chromium image. The issue only affects webhooks, as Chromium itself uses bundled certificates.