### PR TITLE
feat(poppler): add PDF to image conversion route

### DIFF
--- a/.bruno/PDF Engines/Convert/Convert To Image.bru
+++ b/.bruno/PDF Engines/Convert/Convert To Image.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Convert To Image
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/forms/pdfengines/convert/image
+  body: multipartForm
+  auth: none
+}
+
+body:multipart-form {
+  files: @file(../../test/integration/testdata/pages_3.pdf)
+  ~format: png
+  ~dpi: 150
+  ~quality: 100
+  ~firstPage: 1
+  ~lastPage: 3
+}
+
+headers {
+  ~Gotenberg-Output-Filename: rasterized
+  ~Gotenberg-Webhook-Url: http://localhost:8080/webhook
+  ~Gotenberg-Webhook-Error-Url: http://localhost:8080/webhook/error
+  ~Gotenberg-Webhook-Events-Url: http://localhost:8080/webhook/events
+  ~Gotenberg-Webhook-Method: POST
+  ~Gotenberg-Webhook-Error-Method: POST
+  ~Gotenberg-Webhook-Extra-Http-Headers: {"X-Custom":"value"}
+}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -145,6 +145,8 @@ RUN apt-get update -qq \
         fonts-noto-core \
         # Install QPDF & ExifTool (PDF engines).
         qpdf exiftool \
+        # PDF rasterization (pdftoppm).
+        poppler-utils \
     # See https://github.com/nextcloud/docker/issues/380.
     && mkdir -p /usr/share/man/man1 \
     # Cleanup.
@@ -189,6 +191,7 @@ ENV PDFTK_BIN_PATH=/usr/bin/pdftk
 ENV QPDF_BIN_PATH=/usr/bin/qpdf
 ENV EXIFTOOL_BIN_PATH=/usr/bin/exiftool
 ENV PDFCPU_BIN_PATH=/usr/bin/pdfcpu
+ENV PDFTOPPM_BIN_PATH=/usr/bin/pdftoppm
 
 # Capture backing-binary versions at build time so the running process reports
 # them on traces without spawning the binaries at startup or per request.
@@ -201,7 +204,8 @@ COPY --link build/capture-version.sh /opt/gotenberg/capture-version.sh
 RUN bash /opt/gotenberg/capture-version.sh "$GOTENBERG_VERSIONS_DIR_PATH" qpdf "$QPDF_BIN_PATH" --version \
     && bash /opt/gotenberg/capture-version.sh "$GOTENBERG_VERSIONS_DIR_PATH" exiftool "$EXIFTOOL_BIN_PATH" -ver \
     && bash /opt/gotenberg/capture-version.sh "$GOTENBERG_VERSIONS_DIR_PATH" pdftk "$PDFTK_BIN_PATH" --version \
-    && bash /opt/gotenberg/capture-version.sh "$GOTENBERG_VERSIONS_DIR_PATH" pdfcpu "$PDFCPU_BIN_PATH" version
+    && bash /opt/gotenberg/capture-version.sh "$GOTENBERG_VERSIONS_DIR_PATH" pdfcpu "$PDFCPU_BIN_PATH" version \
+    && bash /opt/gotenberg/capture-version.sh "$GOTENBERG_VERSIONS_DIR_PATH" pdftoppm bash -c "$PDFTOPPM_BIN_PATH -v 2>&1"
 
 # OpenTelemetry defaults (noop - no telemetry overhead unless explicitly enabled).
 ENV OTEL_TRACES_EXPORTER=none

--- a/pkg/modules/poppler/doc.go
+++ b/pkg/modules/poppler/doc.go
@@ -1,0 +1,5 @@
+// Package poppler rasterizes PDF files into images using the pdftoppm command
+// from the Poppler utilities. It exposes the
+// /forms/pdfengines/convert/image route, which turns each page of one or more
+// PDFs into a PNG, JPEG, or TIFF image.
+package poppler

--- a/pkg/modules/poppler/poppler.go
+++ b/pkg/modules/poppler/poppler.go
@@ -1,0 +1,236 @@
+package poppler
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+	"syscall"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/gotenberg/gotenberg/v8/pkg/gotenberg"
+	"github.com/gotenberg/gotenberg/v8/pkg/modules/api"
+)
+
+func init() {
+	gotenberg.MustRegisterModule(new(Poppler))
+}
+
+// Poppler abstracts the CLI tool pdftoppm and rasterizes PDF files into images.
+type Poppler struct {
+	binPath string
+
+	version     string
+	versionOnce sync.Once
+}
+
+// ImageConvertOptions are the options for [Poppler.Rasterize].
+type ImageConvertOptions struct {
+	// Format is the output image format: "png", "jpeg", or "tiff".
+	Format string
+
+	// Dpi is the resolution, in dots per inch, used to rasterize each page.
+	Dpi int
+
+	// Quality is the JPEG quality, from 1 to 100. Ignored for other formats.
+	Quality int
+
+	// FirstPage is the first page to rasterize. Zero means the first page.
+	FirstPage int
+
+	// LastPage is the last page to rasterize. Zero means the last page.
+	LastPage int
+}
+
+// Descriptor returns a [Poppler]'s module descriptor.
+func (engine *Poppler) Descriptor() gotenberg.ModuleDescriptor {
+	return gotenberg.ModuleDescriptor{
+		ID:  "poppler",
+		New: func() gotenberg.Module { return new(Poppler) },
+	}
+}
+
+// Provision sets the module properties.
+func (engine *Poppler) Provision(_ *gotenberg.Context) error {
+	binPath, ok := os.LookupEnv("PDFTOPPM_BIN_PATH")
+	if !ok {
+		return errors.New("PDFTOPPM_BIN_PATH environment variable is not set; set it to the absolute path of the pdftoppm binary")
+	}
+
+	engine.binPath = binPath
+
+	return nil
+}
+
+// Validate validates the module properties.
+func (engine *Poppler) Validate() error {
+	_, err := os.Stat(engine.binPath)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("pdftoppm binary path does not exist: %w", err)
+	}
+
+	return nil
+}
+
+// Debug returns additional debug data.
+func (engine *Poppler) Debug() map[string]any {
+	return map[string]any{"version": engine.detectVersion()}
+}
+
+// Routes returns the routes provided by [Poppler].
+func (engine *Poppler) Routes() ([]api.Route, error) {
+	return []api.Route{
+		convertImageRoute(engine),
+	}, nil
+}
+
+// detectVersion resolves the pdftoppm version once, preferring the value
+// captured at image build time so it never spawns pdftoppm at runtime. It
+// falls back to running pdftoppm -v for local or non-Docker builds.
+func (engine *Poppler) detectVersion() string {
+	engine.versionOnce.Do(func() {
+		if v, ok := gotenberg.BuildVersion("pdftoppm"); ok {
+			engine.version = v
+			return
+		}
+
+		cmd := exec.Command(engine.binPath, "-v") //nolint:gosec
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+		// pdftoppm writes its version banner to stderr.
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			engine.version = err.Error()
+			return
+		}
+
+		lines := bytes.SplitN(output, []byte("\n"), 2)
+		if len(lines) > 0 {
+			engine.version = string(bytes.TrimSpace(lines[0]))
+			return
+		}
+
+		engine.version = "Unable to determine Poppler version"
+	})
+
+	return engine.version
+}
+
+// spanAttrs returns the client-span attributes for a pdftoppm invocation: the
+// server address and the pdftoppm version, plus any extra attributes. The
+// version rides on every span so a trace records which pdftoppm ran the
+// operation.
+func (engine *Poppler) spanAttrs(extra ...attribute.KeyValue) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 2+len(extra))
+	attrs = append(attrs, semconv.ServerAddress(engine.binPath))
+	if v := engine.detectVersion(); v != "" {
+		attrs = append(attrs, attribute.String("gotenberg.poppler.version", v))
+	}
+
+	return append(attrs, extra...)
+}
+
+// formatFlag maps an [ImageConvertOptions.Format] to its pdftoppm flag.
+func formatFlag(format string) string {
+	switch format {
+	case "jpeg":
+		return "-jpeg"
+	case "tiff":
+		return "-tiff"
+	default:
+		return "-png"
+	}
+}
+
+// Rasterize converts each page of the PDF at inputPath into an image, writing
+// the images into outputDirPath. It returns the generated image paths in page
+// order. The caller owns outputDirPath and is expected to provide an empty
+// directory.
+func (engine *Poppler) Rasterize(ctx context.Context, logger *slog.Logger, inputPath, outputDirPath string, opts ImageConvertOptions) ([]string, error) {
+	ctx, span := gotenberg.Tracer().Start(ctx, "poppler.Rasterize",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(engine.spanAttrs()...),
+	)
+	defer span.End()
+
+	args := make([]string, 0, 12)
+	args = append(args, "-r", strconv.Itoa(opts.Dpi))
+	args = append(args, formatFlag(opts.Format))
+	if opts.Format == "jpeg" && opts.Quality > 0 {
+		args = append(args, "-jpegopt", fmt.Sprintf("quality=%d", opts.Quality))
+	}
+	if opts.FirstPage > 0 {
+		args = append(args, "-f", strconv.Itoa(opts.FirstPage))
+	}
+	if opts.LastPage > 0 {
+		args = append(args, "-l", strconv.Itoa(opts.LastPage))
+	}
+	// pdftoppm writes <root>-<page>.<ext> for every page.
+	args = append(args, inputPath, filepath.Join(outputDirPath, "page"))
+
+	cmd, err := gotenberg.CommandContext(ctx, logger, engine.binPath, args...)
+	if err != nil {
+		err = fmt.Errorf("create command: %w", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	_, err = cmd.Exec()
+	if err != nil {
+		err = fmt.Errorf("rasterize PDF with pdftoppm: %w", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	paths, err := imagePaths(outputDirPath)
+	if err != nil {
+		err = fmt.Errorf("collect generated images: %w", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	if len(paths) == 0 {
+		err = errors.New("pdftoppm produced no images")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return paths, nil
+}
+
+// imagePaths lists the files generated by pdftoppm in dirPath, sorted in page
+// order. pdftoppm zero-pads the page number, so a lexical sort matches the page
+// order.
+func imagePaths(dirPath string) ([]string, error) {
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return nil, fmt.Errorf("read output directory: %w", err)
+	}
+
+	var paths []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		paths = append(paths, filepath.Join(dirPath, entry.Name()))
+	}
+
+	sort.Strings(paths)
+	return paths, nil
+}

--- a/pkg/modules/poppler/poppler_test.go
+++ b/pkg/modules/poppler/poppler_test.go
@@ -1,0 +1,171 @@
+package poppler
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/gotenberg/gotenberg/v8/pkg/gotenberg"
+	"github.com/gotenberg/gotenberg/v8/pkg/modules/api"
+)
+
+func TestPoppler_Descriptor(t *testing.T) {
+	descriptor := new(Poppler).Descriptor()
+
+	if descriptor.ID != "poppler" {
+		t.Errorf("expected ID 'poppler', got '%s'", descriptor.ID)
+	}
+
+	if _, ok := descriptor.New().(*Poppler); !ok {
+		t.Error("expected New to return a *Poppler")
+	}
+}
+
+func TestPoppler_Provision(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		envValue  string
+		setEnv    bool
+		expectErr bool
+	}{
+		{name: "env not set", setEnv: false, expectErr: true},
+		{name: "env set", setEnv: true, envValue: "/usr/bin/pdftoppm", expectErr: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("PDFTOPPM_BIN_PATH", "")
+			if !tc.setEnv {
+				os.Unsetenv("PDFTOPPM_BIN_PATH")
+			} else {
+				t.Setenv("PDFTOPPM_BIN_PATH", tc.envValue)
+			}
+
+			engine := new(Poppler)
+			err := engine.Provision(nil)
+
+			if tc.expectErr && err == nil {
+				t.Fatal("expected an error, got none")
+			}
+			if !tc.expectErr {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				if engine.binPath != tc.envValue {
+					t.Errorf("expected binPath '%s', got '%s'", tc.envValue, engine.binPath)
+				}
+			}
+		})
+	}
+}
+
+func TestPoppler_Validate(t *testing.T) {
+	existing := filepath.Join(t.TempDir(), "pdftoppm")
+	if err := os.WriteFile(existing, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("create fake binary: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		binPath   string
+		expectErr bool
+	}{
+		{name: "existing path", binPath: existing, expectErr: false},
+		{name: "missing path", binPath: filepath.Join(t.TempDir(), "nope"), expectErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := &Poppler{binPath: tc.binPath}
+			err := engine.Validate()
+
+			if tc.expectErr && err == nil {
+				t.Fatal("expected an error, got none")
+			}
+			if !tc.expectErr && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestPoppler_Routes(t *testing.T) {
+	routes, err := new(Poppler).Routes()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
+	if routes[0].Path != "/forms/pdfengines/convert/image" {
+		t.Errorf("unexpected route path: %s", routes[0].Path)
+	}
+}
+
+func TestFormatFlag(t *testing.T) {
+	for _, tc := range []struct {
+		format   string
+		expected string
+	}{
+		{"png", "-png"},
+		{"jpeg", "-jpeg"},
+		{"tiff", "-tiff"},
+		{"", "-png"},
+		{"unknown", "-png"},
+	} {
+		if got := formatFlag(tc.format); got != tc.expected {
+			t.Errorf("formatFlag(%q) = %q, want %q", tc.format, got, tc.expected)
+		}
+	}
+}
+
+func TestImageExtension(t *testing.T) {
+	for _, tc := range []struct {
+		format   string
+		expected string
+	}{
+		{"png", "png"},
+		{"jpeg", "jpeg"},
+		{"tiff", "tiff"},
+		{"", "png"},
+		{"unknown", "png"},
+	} {
+		if got := imageExtension(tc.format); got != tc.expected {
+			t.Errorf("imageExtension(%q) = %q, want %q", tc.format, got, tc.expected)
+		}
+	}
+}
+
+func TestImagePaths(t *testing.T) {
+	dir := t.TempDir()
+	// pdftoppm zero-pads page numbers, so the lexical sort matches page order.
+	names := []string{"page-03.png", "page-01.png", "page-02.png"}
+	for _, name := range names {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("img"), 0o644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	got, err := imagePaths(dir)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	want := []string{
+		filepath.Join(dir, "page-01.png"),
+		filepath.Join(dir, "page-02.png"),
+		filepath.Join(dir, "page-03.png"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("imagePaths() = %v, want %v", got, want)
+	}
+}
+
+// Ensure Poppler satisfies the interfaces it is expected to.
+var (
+	_ gotenberg.Module      = (*Poppler)(nil)
+	_ gotenberg.Validator   = (*Poppler)(nil)
+	_ gotenberg.Provisioner = (*Poppler)(nil)
+	_ gotenberg.Debuggable  = (*Poppler)(nil)
+	_ api.Router            = (*Poppler)(nil)
+)

--- a/pkg/modules/poppler/routes.go
+++ b/pkg/modules/poppler/routes.go
@@ -1,0 +1,148 @@
+package poppler
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+
+	"github.com/gotenberg/gotenberg/v8/pkg/modules/api"
+)
+
+// defaultDpi is the resolution used when the client omits the dpi field.
+const defaultDpi = 150
+
+// imageExtension maps an [ImageConvertOptions.Format] to the file extension
+// used for the response. JPEG and TIFF reuse the format name for consistency
+// with the Chromium screenshot routes, even though pdftoppm writes .jpg/.tif.
+func imageExtension(format string) string {
+	switch format {
+	case "jpeg":
+		return "jpeg"
+	case "tiff":
+		return "tiff"
+	default:
+		return "png"
+	}
+}
+
+// FormDataPopplerImageOptions reads the [ImageConvertOptions] from the form
+// data.
+func FormDataPopplerImageOptions(form *api.FormData) ImageConvertOptions {
+	options := ImageConvertOptions{
+		Format:  "png",
+		Dpi:     defaultDpi,
+		Quality: 100,
+	}
+
+	form.
+		Custom("format", func(value string) error {
+			if value == "" {
+				return nil
+			}
+			if value != "png" && value != "jpeg" && value != "tiff" {
+				return errors.New("wrong value, expected either 'png', 'jpeg' or 'tiff'")
+			}
+			options.Format = value
+			return nil
+		}).
+		Custom("dpi", func(value string) error {
+			if value == "" {
+				return nil
+			}
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return err
+			}
+			if v <= 0 {
+				return errors.New("value must be a positive integer")
+			}
+			options.Dpi = v
+			return nil
+		}).
+		Custom("quality", func(value string) error {
+			if value == "" {
+				return nil
+			}
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return err
+			}
+			if v < 1 || v > 100 {
+				return errors.New("wrong value, expected an integer between 1 and 100")
+			}
+			options.Quality = v
+			return nil
+		}).
+		Int("firstPage", &options.FirstPage, 0).
+		Int("lastPage", &options.LastPage, 0)
+
+	return options
+}
+
+// convertImageRoute returns an [api.Route] which rasterizes PDFs into images.
+func convertImageRoute(engine *Poppler) api.Route {
+	return api.Route{
+		Method:      http.MethodPost,
+		Path:        "/forms/pdfengines/convert/image",
+		IsMultipart: true,
+		Handler: func(c echo.Context) error {
+			ctx := c.Get("context").(*api.Context)
+
+			form := ctx.FormData()
+			options := FormDataPopplerImageOptions(form)
+
+			var inputPaths []string
+			err := form.
+				MandatoryPaths([]string{".pdf"}, &inputPaths).
+				Validate()
+			if err != nil {
+				return fmt.Errorf("validate form data: %w", err)
+			}
+
+			ext := imageExtension(options.Format)
+
+			var outputPaths []string
+			for _, inputPath := range inputPaths {
+				originalName := ctx.OriginalFilename(inputPath)
+				base := strings.TrimSuffix(originalName, filepath.Ext(originalName))
+
+				outputDirPath, err := ctx.CreateSubDirectory(uuid.New().String())
+				if err != nil {
+					return fmt.Errorf("create sub-directory: %w", err)
+				}
+
+				paths, err := engine.Rasterize(ctx, ctx.Log(), inputPath, outputDirPath, options)
+				if err != nil {
+					return fmt.Errorf("rasterize PDF '%s': %w", originalName, err)
+				}
+
+				// Rename each page to a UUID path carrying the requested
+				// extension so the response Content-Type is correct, and keep a
+				// human-readable original filename for the archive entry.
+				for i, path := range paths {
+					newPath := fmt.Sprintf("%s/%s.%s", outputDirPath, uuid.New().String(), ext)
+					err = ctx.Rename(path, newPath)
+					if err != nil {
+						return fmt.Errorf("rename image: %w", err)
+					}
+
+					ctx.RegisterDiskPath(newPath, fmt.Sprintf("%s-%d.%s", base, i+1, ext))
+					outputPaths = append(outputPaths, newPath)
+				}
+			}
+
+			err = ctx.AddOutputPaths(outputPaths...)
+			if err != nil {
+				return fmt.Errorf("add output paths: %w", err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/pkg/standard/chromium/imports.go
+++ b/pkg/standard/chromium/imports.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/pdfcpu"
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/pdfengines"
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/pdftk"
+	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/poppler"
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/prometheus"
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/qpdf"
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/webhook"

--- a/pkg/standard/imports.go
+++ b/pkg/standard/imports.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/pdfcpu"
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/pdfengines"
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/pdftk"
+	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/poppler"
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/prometheus"
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/qpdf"
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/webhook"

--- a/pkg/standard/libreoffice/imports.go
+++ b/pkg/standard/libreoffice/imports.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/pdfcpu"
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/pdfengines"
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/pdftk"
+	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/poppler"
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/prometheus"
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/qpdf"
 	_ "github.com/gotenberg/gotenberg/v8/pkg/modules/webhook"

--- a/test/integration/features/pdfengines_convert_image.feature
+++ b/test/integration/features/pdfengines_convert_image.feature
@@ -1,0 +1,66 @@
+@pdfengines
+@pdfengines-convert-image
+Feature: /forms/pdfengines/convert/image
+
+  Scenario: POST /forms/pdfengines/convert/image (Default PNG)
+    Given I have a default Gotenberg container
+    When I make a "POST" request to Gotenberg at the "/forms/pdfengines/convert/image" endpoint with the following form data and header(s):
+      | files | testdata/page_1.pdf | file |
+    Then the response status code should be 200
+    Then the response header "Content-Type" should be "image/png"
+    Then there should be the following file(s) in the response:
+      | page_1-1.png |
+
+  Scenario: POST /forms/pdfengines/convert/image (JPEG)
+    Given I have a default Gotenberg container
+    When I make a "POST" request to Gotenberg at the "/forms/pdfengines/convert/image" endpoint with the following form data and header(s):
+      | files  | testdata/page_1.pdf | file  |
+      | format | jpeg                | field |
+      | dpi    | 100                 | field |
+    Then the response status code should be 200
+    Then the response header "Content-Type" should be "image/jpeg"
+    Then there should be the following file(s) in the response:
+      | page_1-1.jpeg |
+
+  Scenario: POST /forms/pdfengines/convert/image (Multi-page archive)
+    Given I have a default Gotenberg container
+    When I make a "POST" request to Gotenberg at the "/forms/pdfengines/convert/image" endpoint with the following form data and header(s):
+      | files | testdata/pages_3.pdf | file |
+    Then the response status code should be 200
+    Then the response header "Content-Type" should be "application/zip"
+    Then there should be the following file(s) in the response:
+      | pages_3-1.png |
+      | pages_3-2.png |
+      | pages_3-3.png |
+
+  Scenario: POST /forms/pdfengines/convert/image (Page range)
+    Given I have a default Gotenberg container
+    When I make a "POST" request to Gotenberg at the "/forms/pdfengines/convert/image" endpoint with the following form data and header(s):
+      | files     | testdata/pages_3.pdf | file  |
+      | firstPage | 2                    | field |
+      | lastPage  | 3                    | field |
+    Then the response status code should be 200
+    Then the response header "Content-Type" should be "application/zip"
+    Then there should be the following file(s) in the response:
+      | pages_3-1.png |
+      | pages_3-2.png |
+
+  Scenario: POST /forms/pdfengines/convert/image (Bad Request)
+    Given I have a default Gotenberg container
+    When I make a "POST" request to Gotenberg at the "/forms/pdfengines/convert/image" endpoint with the following form data and header(s):
+      | files  | testdata/page_1.pdf | file  |
+      | format | foo                 | field |
+    Then the response status code should be 400
+    Then the response header "Content-Type" should be "text/plain; charset=UTF-8"
+    Then the response body should match string:
+      """
+      Invalid form data: form field 'format' is invalid (got 'foo', resulting to wrong value, expected either 'png', 'jpeg' or 'tiff')
+      """
+    When I make a "POST" request to Gotenberg at the "/forms/pdfengines/convert/image" endpoint with the following form data and header(s):
+      | format | png | field |
+    Then the response status code should be 400
+    Then the response header "Content-Type" should be "text/plain; charset=UTF-8"
+    Then the response body should match string:
+      """
+      Invalid form data: no form file found for extensions: [.pdf]
+      """


### PR DESCRIPTION
Add a new poppler module wrapping pdftoppm to rasterize PDFs into images, exposed at POST /forms/pdfengines/convert/image. Each page becomes a PNG, JPEG, or TIFF; a single page returns the image directly while multiple pages return a ZIP archive.

The module follows the qpdf pattern: it reads PDFTOPPM_BIN_PATH, traces the binary call with an OTEL client span, and self-registers via the standard imports. poppler-utils is added to the Docker image, with its version captured at build time.