### PR TITLE
feat: add bulk stamp route

### DIFF
--- a/.bruno/PDF Engines/Stamp/Bulk Stamp PDF.bru
+++ b/.bruno/PDF Engines/Stamp/Bulk Stamp PDF.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Bulk Stamp PDF
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/forms/pdfengines/stamp/bulk
+  body: multipartForm
+  auth: none
+}
+
+body:multipart-form {
+  files: @file(../../test/integration/testdata/page_1.pdf)
+  ~stamp: @file(../../test/integration/testdata/watermark.png)
+  stamps: [{"source":"text","expression":"APPROVED","options":{"rot":"45","scale":"0.5 abs"}},{"source":"image","file":"watermark.png","options":{"pos":"br","scale":"0.2 abs"}}]
+  ~downloadFrom: [{"url":"https://example.com/stamp.png","field":"stamp"}]
+}
+
+headers {
+  ~Gotenberg-Output-Filename: stamped
+  ~Gotenberg-Webhook-Url: http://localhost:8080/webhook
+  ~Gotenberg-Webhook-Error-Url: http://localhost:8080/webhook/error
+  ~Gotenberg-Webhook-Events-Url: http://localhost:8080/webhook/events
+  ~Gotenberg-Webhook-Method: POST
+  ~Gotenberg-Webhook-Error-Method: POST
+  ~Gotenberg-Webhook-Extra-Http-Headers: {"X-Custom":"value"}
+}

--- a/pkg/modules/api/formdata.go
+++ b/pkg/modules/api/formdata.go
@@ -479,6 +479,21 @@ func (form *FormData) Stamp(target *string) *FormData {
 	return form
 }
 
+// Stamps binds the absolute paths of the form data files that should be
+// used as stamp sources. Only files uploaded with the "stamp" field name
+// will be included.
+func (form *FormData) Stamps(target *[]string) *FormData {
+	if form.errors != nil {
+		return form
+	}
+
+	if paths, ok := form.filesByField[StampFormField]; ok {
+		*target = append(*target, paths...)
+	}
+
+	return form
+}
+
 // FacturXXml binds the absolute path of the uploaded Factur-X CII invoice
 // XML. Only a file uploaded with the "facturxXml" field name is included.
 func (form *FormData) FacturXXml(target *string) *FormData {

--- a/pkg/modules/pdfengines/bulk_stamp_test.go
+++ b/pkg/modules/pdfengines/bulk_stamp_test.go
@@ -1,0 +1,230 @@
+package pdfengines
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/gotenberg/gotenberg/v8/pkg/gotenberg"
+	"github.com/gotenberg/gotenberg/v8/pkg/modules/api"
+)
+
+func TestFormDataPdfBulkStamps(t *testing.T) {
+	t.Run("parses valid entries", func(t *testing.T) {
+		ctx := &api.ContextMock{Context: &api.Context{}}
+		ctx.SetValues(map[string][]string{
+			"stamps": {`[
+				{"source":"text","expression":"CONFIDENTIAL","pages":"1","options":{"rot":"45"}},
+				{"source":"image","file":"watermark.png","options":{"pos":"br"}}
+			]`},
+		})
+
+		form := ctx.FormData()
+		got := formDataPdfBulkStamps(form, true)
+		if form.Validate() != nil {
+			t.Fatalf("expected no validation error, got %v", form.Validate())
+		}
+
+		want := []bulkStampSpec{
+			{
+				Source:     gotenberg.StampSourceText,
+				Expression: "CONFIDENTIAL",
+				Pages:      "1",
+				Options:    map[string]string{"rot": "45"},
+			},
+			{
+				Source:  gotenberg.StampSourceImage,
+				File:    "watermark.png",
+				Options: map[string]string{"pos": "br"},
+			},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("bulk stamps = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("rejects missing expression for text source", func(t *testing.T) {
+		ctx := &api.ContextMock{Context: &api.Context{}}
+		ctx.SetValues(map[string][]string{
+			"stamps": {`[{"source":"text"}]`},
+		})
+
+		form := ctx.FormData()
+		_ = formDataPdfBulkStamps(form, true)
+		err := form.Validate()
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		want := "form field 'stamps' is invalid (got '[{\"source\":\"text\"}]', resulting to entry 0 requires a non-empty expression for text source)"
+		if err.Error() != want {
+			t.Fatalf("error = %q, want %q", err.Error(), want)
+		}
+	})
+
+	t.Run("rejects missing file for image source", func(t *testing.T) {
+		ctx := &api.ContextMock{Context: &api.Context{}}
+		ctx.SetValues(map[string][]string{
+			"stamps": {`[{"source":"image"}]`},
+		})
+
+		form := ctx.FormData()
+		_ = formDataPdfBulkStamps(form, true)
+		err := form.Validate()
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		want := "form field 'stamps' is invalid (got '[{\"source\":\"image\"}]', resulting to entry 0 requires a non-empty file for image or pdf source)"
+		if err.Error() != want {
+			t.Fatalf("error = %q, want %q", err.Error(), want)
+		}
+	})
+}
+
+func TestResolveBulkStamps(t *testing.T) {
+	t.Run("resolves uploaded stamp files", func(t *testing.T) {
+		ctx := &api.Context{}
+		stamps, err := resolveBulkStamps(ctx, []bulkStampSpec{
+			{
+				Source:     gotenberg.StampSourceText,
+				Expression: "CONFIDENTIAL",
+				Options:    map[string]string{"rot": "45"},
+			},
+			{
+				Source:  gotenberg.StampSourceImage,
+				File:    "watermark.png",
+				Options: map[string]string{"pos": "br"},
+			},
+		}, []string{"/tmp/watermark.png"})
+		if err != nil {
+			t.Fatalf("resolve bulk stamps: %v", err)
+		}
+
+		want := []gotenberg.Stamp{
+			{
+				Source:     gotenberg.StampSourceText,
+				Expression: "CONFIDENTIAL",
+				Options:    map[string]string{"rot": "45"},
+			},
+			{
+				Source:     gotenberg.StampSourceImage,
+				Expression: "/tmp/watermark.png",
+				Options:    map[string]string{"pos": "br"},
+			},
+		}
+		if !reflect.DeepEqual(stamps, want) {
+			t.Fatalf("resolved stamps = %#v, want %#v", stamps, want)
+		}
+	})
+
+	t.Run("resolves multiple uploaded image stamp files by filename", func(t *testing.T) {
+		ctx := &api.Context{}
+		stamps, err := resolveBulkStamps(ctx, []bulkStampSpec{
+			{
+				Source:  gotenberg.StampSourceImage,
+				File:    "watermark.png",
+				Options: map[string]string{"pos": "br"},
+			},
+			{
+				Source:  gotenberg.StampSourceImage,
+				File:    "image.png",
+				Options: map[string]string{"pos": "tl"},
+			},
+		}, []string{"/tmp/watermark.png", "/tmp/image.png"})
+		if err != nil {
+			t.Fatalf("resolve bulk stamps: %v", err)
+		}
+
+		want := []gotenberg.Stamp{
+			{
+				Source:     gotenberg.StampSourceImage,
+				Expression: "/tmp/watermark.png",
+				Options:    map[string]string{"pos": "br"},
+			},
+			{
+				Source:     gotenberg.StampSourceImage,
+				Expression: "/tmp/image.png",
+				Options:    map[string]string{"pos": "tl"},
+			},
+		}
+		if !reflect.DeepEqual(stamps, want) {
+			t.Fatalf("resolved stamps = %#v, want %#v", stamps, want)
+		}
+	})
+
+	t.Run("rejects unknown uploaded stamp file", func(t *testing.T) {
+		ctx := &api.Context{}
+		_, err := resolveBulkStamps(ctx, []bulkStampSpec{
+			{Source: gotenberg.StampSourceImage, File: "missing.png"},
+		}, nil)
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+
+		var httpErr api.HttpError
+		if !errors.As(err, &httpErr) {
+			t.Fatalf("expected HTTP error, got %v", err)
+		}
+		status, message := httpErr.HttpError()
+		if status != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", status, http.StatusBadRequest)
+		}
+		wantMessage := "Invalid form data: bulk stamp entry 0 references unknown uploaded stamp file 'missing.png'"
+		if message != wantMessage {
+			t.Fatalf("message = %q, want %q", message, wantMessage)
+		}
+	})
+
+	t.Run("rejects duplicate uploaded stamp filenames", func(t *testing.T) {
+		ctx := &api.Context{}
+		_, err := resolveBulkStamps(ctx, []bulkStampSpec{
+			{Source: gotenberg.StampSourceImage, File: "watermark.png"},
+		}, []string{"/tmp/a/watermark.png", "/tmp/b/watermark.png"})
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+
+		var httpErr api.HttpError
+		if !errors.As(err, &httpErr) {
+			t.Fatalf("expected HTTP error, got %v", err)
+		}
+		status, message := httpErr.HttpError()
+		if status != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", status, http.StatusBadRequest)
+		}
+		wantMessage := "Invalid form data: duplicate stamp filename 'watermark.png'; use unique filenames for bulk stamps"
+		if message != wantMessage {
+			t.Fatalf("message = %q, want %q", message, wantMessage)
+		}
+	})
+}
+
+func TestBulkStampStub_AppliesStampsInOrder(t *testing.T) {
+	ctx := &api.Context{}
+	var calls []string
+	engine := &gotenberg.PdfEngineMock{
+		StampMock: func(_ context.Context, _ *slog.Logger, inputPath string, stamp gotenberg.Stamp) error {
+			calls = append(calls, fmt.Sprintf("%s:%s", inputPath, stamp.Expression))
+			return nil
+		},
+	}
+
+	stamps := []gotenberg.Stamp{
+		{Source: gotenberg.StampSourceText, Expression: "one"},
+		{Source: gotenberg.StampSourceText, Expression: "two"},
+	}
+	inputPaths := []string{"a.pdf", "b.pdf"}
+
+	err := BulkStampStub(ctx, engine, stamps, inputPaths)
+	if err != nil {
+		t.Fatalf("bulk stamp stub: %v", err)
+	}
+
+	want := []string{"a.pdf:one", "a.pdf:two", "b.pdf:one", "b.pdf:two"}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %#v, want %#v", calls, want)
+	}
+}

--- a/pkg/modules/pdfengines/pdfengines.go
+++ b/pkg/modules/pdfengines/pdfengines.go
@@ -350,6 +350,7 @@ func (mod *PdfEngines) Routes() ([]api.Route, error) {
 		embedRoute(engine),
 		watermarkRoute(engine),
 		stampRoute(engine),
+		bulkStampRoute(engine),
 		rotateRoute(engine),
 		facturXRoute(engine),
 	}, nil

--- a/pkg/modules/pdfengines/routes.go
+++ b/pkg/modules/pdfengines/routes.go
@@ -17,6 +17,31 @@ import (
 	"github.com/gotenberg/gotenberg/v8/pkg/modules/api"
 )
 
+type bulkStampSpec struct {
+	Source     string            `json:"source"`
+	Expression string            `json:"expression,omitempty"`
+	Pages      string            `json:"pages,omitempty"`
+	Options    map[string]string `json:"options,omitempty"`
+	File       string            `json:"file,omitempty"`
+}
+
+func validateBulkStampSpec(stamp bulkStampSpec, idx int) error {
+	switch stamp.Source {
+	case gotenberg.StampSourceText:
+		if stamp.Expression == "" {
+			return fmt.Errorf("entry %d requires a non-empty expression for text source", idx)
+		}
+	case gotenberg.StampSourceImage, gotenberg.StampSourcePDF:
+		if stamp.File == "" {
+			return fmt.Errorf("entry %d requires a non-empty file for image or pdf source", idx)
+		}
+	default:
+		return fmt.Errorf("entry %d has invalid source '%s'", idx, stamp.Source)
+	}
+
+	return nil
+}
+
 // FormDataPdfSplitMode creates a [gotenberg.SplitMode] from the form data.
 func FormDataPdfSplitMode(form *api.FormData, mandatory bool) gotenberg.SplitMode {
 	var (
@@ -760,6 +785,41 @@ func FormDataPdfStamp(form *api.FormData, mandatory bool) gotenberg.Stamp {
 	return formDataPdfStampOrWatermark(form, "stamp", mandatory)
 }
 
+func formDataPdfBulkStamps(form *api.FormData, mandatory bool) []bulkStampSpec {
+	var stamps []bulkStampSpec
+
+	assign := func(value string) error {
+		if value == "" {
+			return nil
+		}
+
+		err := json.Unmarshal([]byte(value), &stamps)
+		if err != nil {
+			return fmt.Errorf("unmarshal stamps: %w", err)
+		}
+		if len(stamps) == 0 {
+			return errors.New("must contain at least one entry")
+		}
+
+		for i, stamp := range stamps {
+			err := validateBulkStampSpec(stamp, i)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	if mandatory {
+		form.MandatoryCustom("stamps", assign)
+	} else {
+		form.Custom("stamps", assign)
+	}
+
+	return stamps
+}
+
 func formDataPdfStampOrWatermark(form *api.FormData, prefix string, mandatory bool) gotenberg.Stamp {
 	var (
 		source     string
@@ -831,6 +891,12 @@ func FormDataPdfStampFile(form *api.FormData) string {
 	return path
 }
 
+func formDataPdfStampFiles(form *api.FormData) []string {
+	var paths []string
+	form.Stamps(&paths)
+	return paths
+}
+
 // EnsureStampFile validates that, when stamp.Source is image or pdf, an
 // uploaded stamp file was supplied, and replaces stamp.Expression with
 // uploadedFile in that case. Returning an [api] HTTP 400 error prevents
@@ -875,6 +941,73 @@ func EnsureWatermarkFile(watermark *gotenberg.Stamp, uploadedFile string) error 
 	return nil
 }
 
+func resolveBulkStamps(ctx *api.Context, bulkStamps []bulkStampSpec, uploadedPaths []string) ([]gotenberg.Stamp, error) {
+	stampPathsByName := make(map[string]string, len(uploadedPaths))
+	for _, path := range uploadedPaths {
+		filename := ctx.OriginalFilename(path)
+		if existing, ok := stampPathsByName[filename]; ok && existing != path {
+			return nil, api.WrapError(
+				fmt.Errorf("duplicate uploaded stamp filename '%s'", filename),
+				api.NewSentinelHttpError(
+					http.StatusBadRequest,
+					fmt.Sprintf("Invalid form data: duplicate stamp filename '%s'; use unique filenames for bulk stamps", filename),
+				),
+			)
+		}
+		stampPathsByName[filename] = path
+	}
+
+	resolved := make([]gotenberg.Stamp, len(bulkStamps))
+	for i, bulkStamp := range bulkStamps {
+		stamp := gotenberg.Stamp{
+			Source:     bulkStamp.Source,
+			Expression: bulkStamp.Expression,
+			Pages:      bulkStamp.Pages,
+			Options:    bulkStamp.Options,
+		}
+
+		switch bulkStamp.Source {
+		case gotenberg.StampSourceText:
+			if bulkStamp.Expression == "" {
+				return nil, api.WrapError(
+					errors.New("no stamp expression provided for text source"),
+					api.NewSentinelHttpError(
+						http.StatusBadRequest,
+						fmt.Sprintf("Invalid form data: bulk stamp entry %d requires a stamp expression for text source", i),
+					),
+				)
+			}
+		case gotenberg.StampSourceImage, gotenberg.StampSourcePDF:
+			if bulkStamp.File == "" {
+				return nil, api.WrapError(
+					errors.New("no stamp file provided for image or pdf source"),
+					api.NewSentinelHttpError(
+						http.StatusBadRequest,
+						fmt.Sprintf("Invalid form data: bulk stamp entry %d requires an uploaded stamp file for image or pdf source", i),
+					),
+				)
+			}
+
+			path, ok := stampPathsByName[bulkStamp.File]
+			if !ok {
+				return nil, api.WrapError(
+					fmt.Errorf("bulk stamp entry %d references unknown stamp file '%s'", i, bulkStamp.File),
+					api.NewSentinelHttpError(
+						http.StatusBadRequest,
+						fmt.Sprintf("Invalid form data: bulk stamp entry %d references unknown uploaded stamp file '%s'", i, bulkStamp.File),
+					),
+				)
+			}
+
+			stamp.Expression = path
+		}
+
+		resolved[i] = stamp
+	}
+
+	return resolved, nil
+}
+
 // WatermarkStub applies a watermark to a list of PDF files. If the stamp has
 // no source, it does nothing.
 func WatermarkStub(ctx *api.Context, engine gotenberg.PdfEngine, stamp gotenberg.Stamp, inputPaths []string) error {
@@ -886,6 +1019,24 @@ func WatermarkStub(ctx *api.Context, engine gotenberg.PdfEngine, stamp gotenberg
 		err := engine.Watermark(ctx, ctx.Log(), inputPath, stamp)
 		if err != nil {
 			return fmt.Errorf("watermark '%s': %w", inputPath, err)
+		}
+	}
+
+	return nil
+}
+
+// BulkStampStub applies a list of stamps to PDFs in the provided order.
+func BulkStampStub(ctx *api.Context, engine gotenberg.PdfEngine, stamps []gotenberg.Stamp, inputPaths []string) error {
+	if len(stamps) == 0 {
+		return nil
+	}
+
+	for _, inputPath := range inputPaths {
+		for i, stamp := range stamps {
+			err := engine.Stamp(ctx, ctx.Log(), inputPath, stamp)
+			if err != nil {
+				return fmt.Errorf("stamp '%s' entry %d: %w", inputPath, i, err)
+			}
 		}
 	}
 
@@ -1650,6 +1801,48 @@ func stampRoute(engine gotenberg.PdfEngine) api.Route {
 			}
 
 			err = StampStub(ctx, engine, stamp, inputPaths)
+			if err != nil {
+				return fmt.Errorf("stamp PDFs: %w", err)
+			}
+
+			err = ctx.AddOutputPaths(inputPaths...)
+			if err != nil {
+				return fmt.Errorf("add output paths: %w", err)
+			}
+
+			return nil
+		},
+	}
+}
+
+// bulkStampRoute returns an [api.Route] which can add multiple ordered stamps
+// to PDFs.
+func bulkStampRoute(engine gotenberg.PdfEngine) api.Route {
+	return api.Route{
+		Method:      http.MethodPost,
+		Path:        "/forms/pdfengines/stamp/bulk",
+		IsMultipart: true,
+		Handler: func(c echo.Context) error {
+			ctx := c.Get("context").(*api.Context)
+
+			form := ctx.FormData()
+			bulkStamps := formDataPdfBulkStamps(form, true)
+			stampFiles := formDataPdfStampFiles(form)
+
+			var inputPaths []string
+			err := form.
+				MandatoryPaths([]string{".pdf"}, &inputPaths).
+				Validate()
+			if err != nil {
+				return fmt.Errorf("validate form data: %w", err)
+			}
+
+			stamps, err := resolveBulkStamps(ctx, bulkStamps, stampFiles)
+			if err != nil {
+				return fmt.Errorf("validate bulk stamps: %w", err)
+			}
+
+			err = BulkStampStub(ctx, engine, stamps, inputPaths)
 			if err != nil {
 				return fmt.Errorf("stamp PDFs: %w", err)
 			}

--- a/test/integration/features/pdfengines_bulk_stamp.feature
+++ b/test/integration/features/pdfengines_bulk_stamp.feature
@@ -1,0 +1,52 @@
+@pdfengines
+@pdfengines-stamp
+@stamp
+@bulk-stamp
+Feature: /forms/pdfengines/stamp/bulk
+
+  Scenario: POST /forms/pdfengines/stamp/bulk (Text and Image - pdfcpu)
+    Given I have a Gotenberg container with the following environment variable(s):
+      | PDFENGINES_STAMP_ENGINES | pdfcpu |
+    When I make a "POST" request to Gotenberg at the "/forms/pdfengines/stamp/bulk" endpoint with the following form data and header(s):
+      | files  | testdata/page_1.pdf    | file  |
+      | stamp  | testdata/watermark.png | file  |
+      | stamps | [{"source":"text","expression":"CONFIDENTIAL","options":{"rot":"45","scale":"0.5 abs"}},{"source":"image","file":"watermark.png","options":{"pos":"br","scale":"0.2 abs"}}] | field |
+    Then the response status code should be 200
+    Then the response header "Content-Type" should be "application/pdf"
+    Then there should be 1 PDF(s) in the response
+
+  Scenario: POST /forms/pdfengines/stamp/bulk (Multiple Images - pdfcpu)
+    Given I have a Gotenberg container with the following environment variable(s):
+      | PDFENGINES_STAMP_ENGINES | pdfcpu |
+    When I make a "POST" request to Gotenberg at the "/forms/pdfengines/stamp/bulk" endpoint with the following form data and header(s):
+      | files  | testdata/page_1.pdf              | file  |
+      | stamp  | testdata/watermark.png           | file  |
+      | stamp  | testdata/html-with-asset/image.png | file  |
+      | stamps | [{"source":"image","file":"watermark.png","options":{"pos":"br","scale":"0.2 abs"}},{"source":"image","file":"image.png","options":{"pos":"tl","scale":"0.15 abs"}}] | field |
+    Then the response status code should be 200
+    Then the response header "Content-Type" should be "application/pdf"
+    Then there should be 1 PDF(s) in the response
+
+  @download-from
+  Scenario: POST /forms/pdfengines/stamp/bulk (PDF via Download From - pdfcpu)
+    Given I have a Gotenberg container with the following environment variable(s):
+      | PDFENGINES_STAMP_ENGINES | pdfcpu |
+    Given I have a static server
+    When I make a "POST" request to Gotenberg at the "/forms/pdfengines/stamp/bulk" endpoint with the following form data and header(s):
+      | files        | testdata/page_1.pdf                                                                   | file  |
+      | downloadFrom | [{"url":"http://host.docker.internal:%d/static/testdata/page_2.pdf","field":"stamp"}] | field |
+      | stamps       | [{"source":"pdf","file":"page_2.pdf","pages":"1"}]                                    | field |
+    Then the response status code should be 200
+    Then the response header "Content-Type" should be "application/pdf"
+    Then there should be 1 PDF(s) in the response
+
+  Scenario: POST /forms/pdfengines/stamp/bulk (Bad Request - Unknown Uploaded File for Image Source)
+    Given I have a default Gotenberg container
+    When I make a "POST" request to Gotenberg at the "/forms/pdfengines/stamp/bulk" endpoint with the following form data and header(s):
+      | files  | testdata/page_1.pdf                                       | file  |
+      | stamps | [{"source":"image","file":"watermark.png","pages":"1"}] | field |
+    Then the response status code should be 400
+    Then the response body should match string:
+      """
+      Invalid form data: bulk stamp entry 0 references unknown uploaded stamp file 'watermark.png'
+      """


### PR DESCRIPTION
I'm looking to add bulk stamp / multi stamping to gotenberg as this is one of the features I use. This prevents multiple roundtrips to Gotenberg from other services in order to achieve multiple stamps on a pdf. 

If this feature sounds like something you want to add to Gotenberg, then please consider it. 

It's my first time doing a PR to a public Go repo, so let me know if you identify improvements in the code or if you'd want me to go about it differently.

## Summary

Add a new `POST /forms/pdfengines/stamp/bulk` route to apply multiple stamps to a PDF in a defined order.

This keeps the existing stamp route unchanged and adds a bulk variant for requests that need a mix of text, image, or PDF stamps in a single operation.

## API shape

Multipart form data:
- `files`: input PDF(s)
- `stamp`: uploaded stamp file(s) for `image` or `pdf` entries
- `stamps`: JSON array describing the ordered stamps to apply

Example `stamps` payload:

```json
[
  {
    "source": "text",
    "expression": "CONFIDENTIAL",
    "options": { "rot": "45", "scale": "0.5 abs" }
  },
  {
    "source": "image",
    "file": "watermark.png",
    "options": { "pos": "br", "scale": "0.2 abs" }
  }
]