### PR TITLE
fix(libreoffice): return 500 for unexplained UNO errors

### DIFF
--- a/pkg/modules/libreoffice/routes.go
+++ b/pkg/modules/libreoffice/routes.go
@@ -15,6 +15,22 @@ import (
 	"github.com/gotenberg/gotenberg/v8/pkg/modules/pdfengines"
 )
 
+func wrapUnoException(err error, options libreofficeapi.Options) error {
+	wrapped := fmt.Errorf("convert to PDF: %w", err)
+
+	if options.PageRanges == "" && options.Password == "" {
+		return wrapped
+	}
+
+	return api.WrapError(
+		wrapped,
+		api.NewSentinelHttpError(
+			http.StatusBadRequest,
+			fmt.Sprintf("LibreOffice failed to process a document: possible causes include malformed page ranges '%s' (nativePageRanges), or, if a password has been provided, it may not be required. In any case, the exact cause is uncertain.", options.PageRanges),
+		),
+	)
+}
+
 // convertRoute returns an [api.Route] which can convert LibreOffice documents
 // to PDF.
 func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) api.Route {
@@ -406,10 +422,7 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 					}
 
 					if errors.Is(err, libreofficeapi.ErrUnoException) {
-						return api.WrapError(
-							fmt.Errorf("convert to PDF: %w", err),
-							api.NewSentinelHttpError(http.StatusBadRequest, fmt.Sprintf("LibreOffice failed to process a document: possible causes include malformed page ranges '%s' (nativePageRanges), or, if a password has been provided, it may not be required. In any case, the exact cause is uncertain.", options.PageRanges)),
-						)
+						return wrapUnoException(err, options)
 					}
 
 					if errors.Is(err, libreofficeapi.ErrRuntimeException) {

--- a/pkg/modules/libreoffice/routes_test.go
+++ b/pkg/modules/libreoffice/routes_test.go
@@ -1,0 +1,64 @@
+package libreoffice
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gotenberg/gotenberg/v8/pkg/modules/api"
+	libreofficeapi "github.com/gotenberg/gotenberg/v8/pkg/modules/libreoffice/api"
+)
+
+func TestWrapUnoException(t *testing.T) {
+	testCases := []struct {
+		name       string
+		options    libreofficeapi.Options
+		httpStatus int
+	}{
+		{
+			name:       "invalid page ranges",
+			options:    libreofficeapi.Options{PageRanges: "foo"},
+			httpStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "unneeded password",
+			options:    libreofficeapi.Options{Password: "foo"},
+			httpStatus: http.StatusBadRequest,
+		},
+		{
+			name:    "server-side failure",
+			options: libreofficeapi.Options{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			source := fmt.Errorf("supervisor run task: %w", libreofficeapi.ErrUnoException)
+			actual := wrapUnoException(source, testCase.options)
+
+			var httpError api.HttpError
+			if testCase.httpStatus == 0 {
+				if !errors.Is(actual, libreofficeapi.ErrUnoException) {
+					t.Fatalf("expected wrapped UNO exception, got %v", actual)
+				}
+
+				if errors.As(actual, &httpError) {
+					status, _ := httpError.HttpError()
+					t.Fatalf("expected an internal error, got HTTP status %d", status)
+				}
+
+				return
+			}
+
+			if !errors.As(actual, &httpError) {
+				t.Fatal("expected an HTTP error")
+			}
+
+			status, _ := httpError.HttpError()
+			if status != testCase.httpStatus {
+				t.Fatalf("expected HTTP status %d, got %d", testCase.httpStatus, status)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- return unexplained LibreOffice UNO failures as internal server errors
- preserve HTTP 400 for UNO failures associated with client-supplied page ranges or passwords
- add table-driven coverage for all three paths

## Testing

- `make test-unit`
- `go test ./pkg/modules/libreoffice/...`
- `gofmt` on changed Go files
- `git diff --check`

Fixes #1588.
