### PR TITLE
Await thenable js expression

### DIFF
--- a/pkg/modules/chromium/tasks.go
+++ b/pkg/modules/chromium/tasks.go
@@ -593,7 +593,15 @@ func waitForExpressionBeforePrintActionFunc(logger *slog.Logger, disableJavaScri
 				return fmt.Errorf("context done while evaluating '%s': %w", expression, ctx.Err())
 			case <-ticker.C:
 				var ok bool
-				evaluate := chromedp.Evaluate(expression, &ok)
+				// If the provided expression is a async function (thenable) it will be awaited
+				//   (async () => {
+				//		document.querySelector('#accept').click();
+				//		await new Promise(r => setTimeout(r, 2000));
+				//		return true;
+				//	})()
+				evaluate := chromedp.Evaluate(expression, &ok, func(p *runtime.EvaluateParams) *runtime.EvaluateParams {
+					return p.WithAwaitPromise(true)
+				})
 
 				err := evaluate.Do(ctx)
 				if err != nil {


### PR DESCRIPTION
I want to write my wait for expressions like this and chrome seems to support this. I could not test it agains a go compiler due to my work env but it "should compile™"

```js
(async () => {
  document.querySelector('#accept').click();
  await new Promise(r => setTimeout(r, 2000)); // wait 2s
  return true;
})()
```

With this you can write more sophisticated wait for expressions in a "more clean" manner. What do you think?
