### PR TITLE
fix(libreoffice): accept the OOXML PowerPoint show extensions

### DIFF
--- a/pkg/modules/libreoffice/api/api.go
+++ b/pkg/modules/libreoffice/api/api.go
@@ -879,6 +879,8 @@ func (a *Api) Extensions() []string {
 		".potx",
 		".ppm",
 		".pps",
+		".ppsm",
+		".ppsx",
 		".ppt",
 		".pptm",
 		".pptx",


### PR DESCRIPTION
`Api.Extensions()` gates every LibreOffice route through `MandatoryPaths` (see `pkg/modules/libreoffice/routes.go`). It lists the legacy `.pps` but neither `.ppsx` nor `.ppsm`, so a PowerPoint show is rejected on the extension check even though LibreOffice converts it.

Two things suggest the omission is accidental rather than deliberate:

- Every other OOXML macro/non-macro pair is already listed: `docx`/`docm`, `dotx`/`dotm`, `xlsx`/`xlsm`, `xltx`/`xltm`, `pptx`/`pptm`, `potx`/`potm`, `vsdx`/`vsdm`. PowerPoint show is the only family missing its OOXML members.
- `ooxmlExtensions` in `pkg/modules/libreoffice/api/protection.go` already classifies `.ppsx` and `.ppsm` as OOXML for password detection, so `DetectPasswordProtection` is written for input the route never lets through.

No filter mapping is involved. `libreoffice.go` special-cases the extension only for `.csv`; everything else is picked by LibreOffice from the file content. Adding the two entries is the whole fix.

The current workaround is renaming to `.pptx` before upload, since the container is the same, but that loses the original filename.

Backward compatibility: additive only. No CLI flag, environment variable, form field, endpoint or default behaviour changes.
