### PR TITLE
chore: Use renovate to bump go and dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/build"
-    schedule:
-      interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["dockerfile", "gomod", "custom.regex"],
+  "semanticCommits": "enabled",
+  "schedule": ["before 6am on monday"],
+  "packageRules": [
+    {
+      "description": "Dependabot owns Go module dependencies. Renovate only handles the toolchain.",
+      "matchManagers": ["gomod"],
+      "enabled": false
+    },
+    {
+      "description": "Bump the go directive in go.mod. Renovate skips it by default.",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "matchDepNames": ["go"],
+      "enabled": true,
+      "rangeStrategy": "bump",
+      "groupName": "Go toolchain"
+    },
+    {
+      "description": "Keep ARG GOLANG_VERSION in step with the go directive, in a single PR.",
+      "matchManagers": ["dockerfile"],
+      "matchDepNames": ["golang"],
+      "groupName": "Go toolchain"
+    },
+    {
+      "description": "golangci-lint refuses to run when built against an older Go than go.mod targets, so it must move with the toolchain.",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["golangci/golangci-lint"],
+      "groupName": "Go toolchain"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the golangci-lint version pinned as an input to golangci-lint-action.",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "uses: golangci/golangci-lint-action@\\S+\\s+with:\\s+version: (?<currentValue>v\\S+)"
+      ],
+      "depNameTemplate": "golangci/golangci-lint",
+      "datasourceTemplate": "github-releases"
+    }
+  ]
+}


### PR DESCRIPTION
Dependabot doesn't do well bumping versions specified in dockerfile [ARG values](https://github.com/dependabot/dependabot-core/issues/2057).

This PR introduces configuration for [renovate](https://github.com/renovatebot/renovate) which will simultaneously bump the go version in go.mod, the dockerfile ARG value, and the golangci-lint version as [demoed in my fork repo](https://github.com/MarkIannucci/gotenberg/pull/4/changes).

In order for it to work, a gotenberg org owner will need to install the [Renovate GitHub app](https://github.com/apps/renovate) and go through the onboarding after merging this configuration.  Alternatively, you can run renovate using the [Renovate GH Action](https://github.com/renovatebot/github-action) in a GH workflow.  Doing that requires obtaining a `GH_TOKEN` and passing it to the action.  If the maintainers would prefer to go that route, I'm happy to write the action.

Additionally, it is possible to use renovate for all of the deps and delete the dependabot configuration.  I'm happy to do that if the maintainers would prefer.

Partially completes #1634.