### PR TITLE
fix(chromium): fail fast with 503 when Chromium crashes

### DIFF
--- a/pkg/modules/chromium/browser.go
+++ b/pkg/modules/chromium/browser.go
@@ -523,7 +523,44 @@ func (b *chromiumBrowser) do(ctx context.Context, logger *slog.Logger, url strin
 		cancelOnMainPageError:   taskCancel,
 	})
 
+	var (
+		crashed   error
+		crashedMu sync.RWMutex
+	)
+
+	// See https://github.com/gotenberg/gotenberg/issues/1640.
+	listenForEventTargetCrashed(taskCtx, logger, eventTargetCrashedOptions{
+		crashed:   &crashed,
+		crashedMu: &crashedMu,
+		cancel:    taskCancel,
+	})
+
 	runErr := chromedp.Run(taskCtx, tasks...)
+
+	// A crashed renderer is the root cause of every other failure this
+	// conversion may have recorded, so check it first.
+	// See https://github.com/gotenberg/gotenberg/issues/1640.
+	crashedMu.RLock()
+	defer crashedMu.RUnlock()
+
+	if crashed != nil {
+		return fmt.Errorf("handle tasks: %w", crashed)
+	}
+
+	// The browser context is only ever canceled when the browser process
+	// dies or is stopped, never on a request timeout. If the run failed
+	// and the browser context is done, the conversion failed because the
+	// browser went away mid-flight; fail fast with the same crash error
+	// instead of letting the error fall through as a generic context
+	// cancellation. The check is gated on runErr so a successful
+	// conversion is never discarded by a browser death that lands right
+	// after it.
+	// See https://github.com/gotenberg/gotenberg/issues/1640.
+	if runErr != nil {
+		if err := b.ctx.Err(); err != nil {
+			return fmt.Errorf("handle tasks: %w", ErrChromiumCrashed)
+		}
+	}
 
 	// Check event-driven errors first — they take priority over chromedp.Run
 	// errors because they carry the actual root cause (e.g., HTTP 500 from

--- a/pkg/modules/chromium/chromium.go
+++ b/pkg/modules/chromium/chromium.go
@@ -71,6 +71,10 @@ var (
 	// ErrResourceLoadingFailed happens when one or more resources failed to load.
 	ErrResourceLoadingFailed = errors.New("resource loading failed")
 
+	// ErrChromiumCrashed happens when the Chromium renderer crashes during a
+	// conversion.
+	ErrChromiumCrashed = errors.New("chromium crashed")
+
 	// PDF specific.
 
 	// ErrOmitBackgroundWithoutPrintBackground happens if
@@ -1106,6 +1110,8 @@ func chromiumErrorType(err error, queueReason string) string {
 		errors.Is(err, ErrInvalidEvaluationExpression),
 		errors.Is(err, ErrInvalidSelectorQuery):
 		return gotenberg.ErrorTypeInvalidInput
+	case errors.Is(err, ErrChromiumCrashed):
+		return "chromium_unavailable"
 	case errors.Is(err, gotenberg.ErrMaximumQueueSizeExceeded):
 		return queueReason
 	case errors.Is(err, gotenberg.ErrProcessAlreadyRestarting):

--- a/pkg/modules/chromium/errortype_test.go
+++ b/pkg/modules/chromium/errortype_test.go
@@ -21,6 +21,7 @@ func TestChromiumErrorType(t *testing.T) {
 		{"invalid resource http status", ErrInvalidResourceHttpStatusCode, "chromium_unavailable", "invalid_input"},
 		{"loading failed", ErrLoadingFailed, "chromium_unavailable", "invalid_input"},
 		{"resource loading failed", ErrResourceLoadingFailed, "chromium_unavailable", "invalid_input"},
+		{"crashed", ErrChromiumCrashed, "chromium_unavailable", "chromium_unavailable"},
 		{"invalid evaluation expression", ErrInvalidEvaluationExpression, "chromium_unavailable", "invalid_input"},
 		{"invalid selector query", ErrInvalidSelectorQuery, "chromium_unavailable", "invalid_input"},
 		{"pdf queue", gotenberg.ErrMaximumQueueSizeExceeded, "chromium_unavailable", "chromium_unavailable"},

--- a/pkg/modules/chromium/events.go
+++ b/pkg/modules/chromium/events.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/fetch"
+	"github.com/chromedp/cdproto/inspector"
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/cdproto/runtime"
@@ -517,6 +518,38 @@ func listenForEventExceptionThrown(ctx context.Context, logger *slog.Logger, con
 			defer consoleExceptionsMu.Unlock()
 
 			*consoleExceptions = errors.Join(*consoleExceptions, fmt.Errorf("\n%+v", ev.ExceptionDetails))
+		}
+	})
+}
+
+type eventTargetCrashedOptions struct {
+	crashed   *error
+	crashedMu *sync.RWMutex
+	cancel    context.CancelFunc
+}
+
+// listenForEventTargetCrashed listens for the Inspector.targetCrashed event,
+// which Chromium sends when the renderer serving the conversion's tab
+// crashes. chromedp enables the Inspector domain on every target but does
+// not handle this event: left alone, the in-flight CDP command never
+// receives a response and the conversion blocks until the request deadline.
+// Record the crash and cancel the task context so the conversion fails fast
+// instead.
+// See https://github.com/gotenberg/gotenberg/issues/1640.
+func listenForEventTargetCrashed(ctx context.Context, logger *slog.Logger, options eventTargetCrashedOptions) {
+	chromedp.ListenTarget(ctx, func(ev any) {
+		if _, ok := ev.(*inspector.EventTargetCrashed); ok {
+			logger.DebugContext(ctx, "event EventTargetCrashed fired")
+
+			options.crashedMu.Lock()
+			defer options.crashedMu.Unlock()
+
+			*options.crashed = ErrChromiumCrashed
+
+			// Cancel the task context so the in-flight CDP command aborts
+			// immediately instead of waiting for a response the crashed
+			// renderer can never send.
+			options.cancel()
 		}
 	})
 }

--- a/pkg/modules/chromium/routes.go
+++ b/pkg/modules/chromium/routes.go
@@ -1020,6 +1020,16 @@ func handleChromiumError(err error, options Options) error {
 		return nil
 	}
 
+	if errors.Is(err, ErrChromiumCrashed) {
+		return api.WrapError(
+			err,
+			api.NewSentinelHttpError(
+				http.StatusServiceUnavailable,
+				"Chromium crashed while processing the request. Retry, or reduce the workload if the problem persists.",
+			),
+		)
+	}
+
 	if errors.Is(err, ErrInvalidEvaluationExpression) {
 		if options.WaitForExpression == "" {
 			// We do not expect the 'waitWindowStatus' form field to return

--- a/pkg/modules/chromium/routes_test.go
+++ b/pkg/modules/chromium/routes_test.go
@@ -1,0 +1,51 @@
+package chromium
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gotenberg/gotenberg/v8/pkg/modules/api"
+)
+
+// TestHandleChromiumError_Crashed pins the mapping of a Chromium renderer
+// crash to a 503 Service Unavailable. When the renderer crashes mid-conversion,
+// the request must fail fast with 503 rather than hang until the deadline and
+// surface as a generic timeout.
+// See https://github.com/gotenberg/gotenberg/issues/1640.
+func TestHandleChromiumError_Crashed(t *testing.T) {
+	// Mirror the wrapping done by [chromiumBrowser.do].
+	err := handleChromiumError(fmt.Errorf("handle tasks: %w", ErrChromiumCrashed), Options{})
+	if err == nil {
+		t.Fatal("expected an error, got none")
+	}
+
+	status, message := api.ParseError(err)
+	if status != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d (message: %s)", status, http.StatusServiceUnavailable, message)
+	}
+
+	want := "Chromium crashed while processing the request. Retry, or reduce the workload if the problem persists."
+	if message != want {
+		t.Errorf("message = %q, want %q", message, want)
+	}
+}
+
+// TestHandleChromiumError_CrashedTakesPrecedence guards the ordering in
+// [handleChromiumError]: a crash is a server-side failure and must map to 503
+// even when the error chain also carries a marker that another branch would
+// map to a client-error status.
+func TestHandleChromiumError_CrashedTakesPrecedence(t *testing.T) {
+	err := handleChromiumError(
+		fmt.Errorf("handle tasks: %w; %w", ErrChromiumCrashed, ErrInvalidHttpStatusCode),
+		Options{},
+	)
+	if err == nil {
+		t.Fatal("expected an error, got none")
+	}
+
+	status, _ := api.ParseError(err)
+	if status != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", status, http.StatusServiceUnavailable)
+	}
+}

--- a/test/integration/features/chromium_convert_url.feature
+++ b/test/integration/features/chromium_convert_url.feature
@@ -1401,3 +1401,19 @@ Feature: /forms/chromium/convert/url
     Then the response header "Content-Type" should be "application/pdf"
     Then there should be 1 PDF(s) in the response
     Then the "foo.pdf" PDF should have 1 page(s)
+
+  # chrome://crash makes the renderer crash deterministically, the same
+  # failure class as a renderer crash triggered by the page content. The
+  # request must fail fast with a 503 instead of hanging until the API
+  # timeout.
+  # See https://github.com/gotenberg/gotenberg/issues/1640.
+  Scenario: POST /forms/chromium/convert/url (Chromium crash fails fast with 503)
+    Given I have a default Gotenberg container
+    When I make a "POST" request to Gotenberg at the "/forms/chromium/convert/url" endpoint with the following form data and header(s):
+      | url | chrome://crash | field |
+    Then the response status code should be 503
+    Then the response header "Content-Type" should be "text/plain; charset=UTF-8"
+    Then the response body should contain string:
+      """
+      Chromium crashed while processing the request
+      """


### PR DESCRIPTION
Closes #1640

When the renderer crashes mid-conversion, the in-flight CDP command never receives a response, so the request hangs until the API deadline and surfaces as a generic timeout. This listens for `Inspector.targetCrashed` and maps it to an explicit 503 through the existing sentinel-error path.

A dead browser context after a failed run is treated the same way. That check is gated on `runErr != nil`, so a successful conversion is never discarded by a browser death landing just after it.

## Verification

Same request (`url=chrome://crash`, `CHROMIUM_ALLOW_LIST='.+'`), before and after:

| Build | Result |
|---|---|
| `main` | **30.01s** — 503, generic request-timeout body |
| This PR | **0.56s** — 503, crash body |

The service recovers normally: the next conversion returns 200 with a valid PDF in 0.12s.

`chrome://crash` is a deterministic renderer-crash simulation on x86_64. I could not reproduce the reporter's arm64/AVIF trigger, but `Inspector.targetCrashed` is trigger-agnostic, so the detection path is the same.

## Tests

- `routes_test.go` — 503 mapping for the new sentinel error
- `errortype_test.go` — added the taxonomy case
- Integration scenario driving a real renderer crash and asserting the 503 and the crash body

`make fmt`, `golangci-lint` v2.12.2 (0 issues), `go test -race ./pkg/modules/chromium/...`, and the integration scenario all pass locally. No API routes were added or changed — only error mapping inside the existing handler — so the Bruno collection is unchanged.

## Notes

This targets `main` (v8). I noticed #1487 reworks this module for Gotenberg 9 — happy to port the same change there as well if that would be useful.

It also touches `chromium.go` and `routes.go`, which #1639 modifies; glad to rebase if that lands first.
