### PR TITLE
fix(Dockerfile): re-add libreoffice-math so DOCX math formulas render

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -259,7 +259,7 @@ RUN echo "deb http://deb.debian.org/debian trixie-backports main" >> /etc/apt/so
         hyphen-no hyphen-or hyphen-pa hyphen-pl hyphen-pt-br hyphen-pt-pt hyphen-ro hyphen-ru hyphen-sk hyphen-sl \
         hyphen-sr hyphen-sv hyphen-ta hyphen-te hyphen-th hyphen-uk hyphen-zu \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -t trixie-backports \
-        libreoffice-writer libreoffice-calc libreoffice-impress libreoffice-draw python3-uno \
+        libreoffice-writer libreoffice-calc libreoffice-impress libreoffice-draw libreoffice-math python3-uno \
     # unoconverter will look for the Python binary, which has to be at version 3.
     && ln -s /usr/bin/python3 /usr/bin/python \
     # Cleanup.
@@ -386,7 +386,7 @@ RUN echo "deb http://deb.debian.org/debian trixie-backports main" >> /etc/apt/so
         hyphen-no hyphen-or hyphen-pa hyphen-pl hyphen-pt-br hyphen-pt-pt hyphen-ro hyphen-ru hyphen-sk hyphen-sl \
         hyphen-sr hyphen-sv hyphen-ta hyphen-te hyphen-th hyphen-uk hyphen-zu \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -t trixie-backports \
-        libreoffice-writer libreoffice-calc libreoffice-impress libreoffice-draw python3-uno \
+        libreoffice-writer libreoffice-calc libreoffice-impress libreoffice-draw libreoffice-math python3-uno \
     # unoconverter will look for the Python binary, which has to be at version 3.
     && ln -s /usr/bin/python3 /usr/bin/python \
     # Cleanup.


### PR DESCRIPTION
Fixes #1644.

Re-adds `libreoffice-math` to the LibreOffice package list in both final stages (full and `-libreoffice`). The v8.30.0 slimming switched from the `libreoffice` metapackage to an explicit component list, and Math was left out — since then every OMML equation (`m:oMath`, the standard Word format) is silently dropped from DOCX→PDF conversions: the response is still `200` with a valid PDF, the formulas are just missing.

Size impact is small: Math's hard dependencies are already in the image via the other components — the resulting `-libreoffice` image is ~1.05GB, only a few MB over the current one.

**Verification** (repro script and screenshots in #1644):

- Built the `gotenberg-libreoffice` target from this branch (`make build TARGET=gotenberg-libreoffice`, linux/arm64): `dpkg -l` shows `libreoffice-math` installed, and the repro DOCX from #1644 renders its `E = (a+b)/c` formula correctly via `POST /forms/libreoffice/convert`. On the stock `8.36.0` image the formula is absent.
- Independently cross-checked by extending the published `8.34.0-libreoffice` image with only `apt-get install -t trixie-backports libreoffice-math` — same result.

Happy to add a Gherkin scenario with a formula DOCX under `test/integration/` if you'd like one — just point me at the preferred assertion style for content-level checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
