### PR TITLE
fix(libreoffice): report an encrypted .xlsb as password-protected

### DIFF
--- a/pkg/modules/libreoffice/api/protection.go
+++ b/pkg/modules/libreoffice/api/protection.go
@@ -35,12 +35,13 @@ var (
 	zipMagic = []byte{0x50, 0x4b, 0x03, 0x04}
 
 	// An unencrypted OOXML document is always a ZIP package, so any of these
-	// extensions over a compound file means the payload is encrypted. Legacy
-	// binary formats (.doc, .xls, .ppt) are compound files either way and are
-	// deliberately absent.
+	// extensions over a compound file means the payload is encrypted. A .xlsb
+	// workbook stores binary parts inside that same ZIP package, so it belongs
+	// here too. Legacy binary formats (.doc, .xls, .ppt) are compound files
+	// either way and are deliberately absent.
 	ooxmlExtensions = map[string]struct{}{
 		".docx": {}, ".docm": {}, ".dotx": {}, ".dotm": {},
-		".xlsx": {}, ".xlsm": {}, ".xltx": {}, ".xltm": {},
+		".xlsx": {}, ".xlsm": {}, ".xltx": {}, ".xltm": {}, ".xlsb": {},
 		".pptx": {}, ".pptm": {}, ".potx": {}, ".potm": {},
 		".ppsx": {}, ".ppsm": {},
 	}

--- a/pkg/modules/libreoffice/api/protection_test.go
+++ b/pkg/modules/libreoffice/api/protection_test.go
@@ -77,6 +77,11 @@ func TestDetectPasswordProtection(t *testing.T) {
 			want: PasswordProtectionRequired,
 		},
 		{
+			name: "encrypted binary workbook",
+			path: ole2("encrypted.xlsb"),
+			want: PasswordProtectionRequired,
+		},
+		{
 			name: "legacy binary document is inconclusive",
 			path: ole2("legacy.doc"),
 			want: PasswordProtectionUnknown,


### PR DESCRIPTION
Uploading a password-protected `.xlsb` workbook to `/forms/libreoffice/convert` without its password answers 500 with the unattributable-failure message. The same workbook saved as `.xlsx` answers 400 with "The document '...' is password-protected. Provide its password in the 'password' form field."

`Api.Extensions()` accepts `.xlsb` (`pkg/modules/libreoffice/api/api.go:938`), so the upload reaches LibreOffice, which aborts on import and exits with the UNO exception code. `routes.go:445` then calls `DetectPasswordProtection` to attribute that exit code, and the switch at `routes.go:449` picks a message from the verdict.

The verdict is wrong. `DetectPasswordProtection` reads the file's magic and, on the compound-file signature, looks the extension up in `ooxmlExtensions` (`pkg/modules/libreoffice/api/protection.go:79`). That map lists `.xlsx`, `.xlsm`, `.xltx` and `.xltm` but not `.xlsb` (`protection.go:44`), so an encrypted binary workbook returns `PasswordProtectionUnknown`. No password branch of the switch matches an unknown verdict, and with no page ranges set the switch falls to its `default`, which is `http.StatusInternalServerError` (`routes.go:460`). The client is told the server failed when the request was the problem.

The map's premise holds for `.xlsb`. An Excel Binary Workbook is an Open Packaging Conventions ZIP whose parts happen to be binary rather than XML, so an unencrypted `.xlsb` starts with the ZIP local file header, never with the compound-file signature. A compound file carrying that extension is an MS-OFFCRYPTO container, exactly as it is for `.xlsx`. `.xlsb` is the only Excel extension in `Api.Extensions()` missing from the map; the legacy `.xls`, which is a compound file whether or not it is encrypted, stays out.

Adding `.xlsb` to `ooxmlExtensions` is the whole fix. The regression test is a new case in the existing `TestDetectPasswordProtection` table, alongside the `.docx` and `.xlsx` cases it mirrors.

Verification, on macOS with the go1.27.0 toolchain that go.mod selects and golangci-lint v2.13.2:

- `go test -count=1 -run 'TestDetectPasswordProtection$' -v ./pkg/modules/libreoffice/api/` on the parent commit: `--- FAIL: TestDetectPasswordProtection/encrypted_binary_workbook`, reporting `= 0, want 2`, that is `PasswordProtectionUnknown` where `PasswordProtectionRequired` is expected. Every other case passes.
- The same command with the fix: `ok github.com/gotenberg/gotenberg/v8/pkg/modules/libreoffice/api`.
- `go test -race -count=1 ./...`, the `make test-unit` command: every package `ok`, no failures.
- `golangci-lint run`: `0 issues.`
- `golangci-lint fmt --diff`: no output.

`make test-integration TAGS=libreoffice-convert` is unaffected by this change and was not run here: this Mac has no Docker or LibreOffice, and no integration fixture is a `.xlsb`.

Backward compatibility: additive. No CLI flag, environment variable, form field, endpoint or default value changes. A `.xlsb` that is not encrypted is a ZIP and never reaches the compound-file branch, so its verdict is unchanged.
